### PR TITLE
Fix auto-tag release trigger + default DB path

### DIFF
--- a/.claude/skills/search-copilot-chats/SKILL.md
+++ b/.claude/skills/search-copilot-chats/SKILL.md
@@ -39,15 +39,30 @@ See [claude-plugins.dev](https://claude-plugins.dev) for browsing available skil
 
 ## Prerequisites
 
-- **CLI**: `copilot-session-tools` — installed via `uv` from `C:\_SRC\copilot-session-tools`
-- **Database**: `C:\_SRC\copilot-session-tools\copilot_chats.db` (run `stats` for current size/count)
-- **Run from repo root**: The CLI defaults to `./copilot_chats.db` in the current directory
+The `copilot-session-tools` CLI must be installed and available on PATH. The database is stored at `~/.copilot-session-tools/copilot_chats.db` by default.
 
-All commands below assume you `cd` to the repo first:
+### Step 0: Ensure CLI is installed
+
+Check if the CLI is available:
 
 ```powershell
-cd C:\_SRC\copilot-session-tools
+copilot-session-tools --help
 ```
+
+If the command is not found, install it using whichever package manager is available (in preference order):
+
+```bash
+# Option 1: uv (recommended — fast, isolated)
+uv tool install copilot-session-tools[all]
+
+# Option 2: pipx (isolated)
+pipx install copilot-session-tools[all]
+
+# Option 3: pip (global)
+pip install copilot-session-tools[all]
+```
+
+The `[all]` extra includes both the CLI and web viewer dependencies.
 
 ## Favor CLI over Python
 
@@ -59,7 +74,7 @@ cd C:\_SRC\copilot-session-tools
 For direct SQL queries, use `sqlite3` on the database file rather than writing Python:
 
 ```powershell
-sqlite3 "C:\_SRC\copilot-session-tools\copilot_chats.db" "SELECT session_id, workspace_name, created_at FROM sessions ORDER BY created_at DESC LIMIT 10"
+sqlite3 "$HOME/.copilot-session-tools/copilot_chats.db" "SELECT session_id, workspace_name, created_at FROM sessions ORDER BY created_at DESC LIMIT 10"
 ```
 
 ## Instructions
@@ -281,23 +296,23 @@ When the CLI search doesn't support your query shape, use SQLite directly:
 
 ```powershell
 # Find sessions by workspace name
-sqlite3 "C:\_SRC\copilot-session-tools\copilot_chats.db" `
+sqlite3 "$HOME/.copilot-session-tools/copilot_chats.db" `
   "SELECT session_id, workspace_name, created_at FROM sessions WHERE workspace_name LIKE '%zts%' ORDER BY created_at DESC LIMIT 20"
 
 # Count messages per session (find long conversations)
-sqlite3 "C:\_SRC\copilot-session-tools\copilot_chats.db" `
+sqlite3 "$HOME/.copilot-session-tools/copilot_chats.db" `
   "SELECT s.session_id, s.workspace_name, COUNT(m.id) as msg_count FROM sessions s JOIN messages m ON s.session_id = m.session_id GROUP BY s.session_id ORDER BY msg_count DESC LIMIT 20"
 
 # Find sessions with tool invocations of a specific tool
-sqlite3 "C:\_SRC\copilot-session-tools\copilot_chats.db" `
+sqlite3 "$HOME/.copilot-session-tools/copilot_chats.db" `
   "SELECT DISTINCT s.session_id, s.workspace_name, s.created_at FROM sessions s JOIN messages m ON s.session_id = m.session_id JOIN tool_invocations ti ON m.id = ti.message_id WHERE ti.name LIKE '%build%' ORDER BY s.created_at DESC LIMIT 20"
 
 # Find file changes by path pattern
-sqlite3 "C:\_SRC\copilot-session-tools\copilot_chats.db" `
+sqlite3 "$HOME/.copilot-session-tools/copilot_chats.db" `
   "SELECT DISTINCT s.session_id, s.workspace_name, fc.path FROM sessions s JOIN messages m ON s.session_id = m.session_id JOIN file_changes fc ON m.id = fc.message_id WHERE fc.path LIKE '%Dockerfile%' ORDER BY s.created_at DESC LIMIT 20"
 
 # Find command runs
-sqlite3 "C:\_SRC\copilot-session-tools\copilot_chats.db" `
+sqlite3 "$HOME/.copilot-session-tools/copilot_chats.db" `
   "SELECT s.session_id, cr.command, cr.status FROM sessions s JOIN messages m ON s.session_id = m.session_id JOIN command_runs cr ON m.id = cr.message_id WHERE cr.command LIKE '%az pipelines%' ORDER BY cr.timestamp DESC LIMIT 20"
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   lint:
@@ -155,3 +156,11 @@ jobs:
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
           echo "🏷️ Created and pushed tag v${{ steps.version.outputs.version }}"
+
+      - name: Trigger release workflow
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml --field tag="v${{ steps.version.outputs.version }}"
+          echo "🚀 Triggered release workflow for v${{ steps.version.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,19 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.1.2)'
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   lint:
@@ -16,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -43,6 +54,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -65,6 +78,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -76,7 +91,7 @@ jobs:
 
       - name: Verify tag matches package version
         run: |
-          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          TAG_VERSION=${RELEASE_TAG#v}
           PKG_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
@@ -122,7 +137,7 @@ jobs:
 
       - name: Install from TestPyPI
         run: |
-          TAG_VERSION=${GITHUB_REF_NAME#v}
+          TAG_VERSION=${RELEASE_TAG#v}
           for i in 1 2 3 4 5; do
             echo "Attempt $i: installing copilot-session-tools==${TAG_VERSION} from TestPyPI..."
             pip install --index-url https://test.pypi.org/simple/ \
@@ -137,7 +152,7 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          TAG_VERSION=${GITHUB_REF_NAME#v}
+          TAG_VERSION=${RELEASE_TAG#v}
           python -c "from copilot_session_tools import __version__; tag='${TAG_VERSION}'; assert __version__ == tag, f'{__version__} != {tag}'"
 
       - name: Verify CLI works
@@ -168,10 +183,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,16 +68,20 @@ git push origin <branch>
 # Create PR targeting main
 ```
 
-CI enforces that every PR bumps the version. Once approved and merged:
+CI enforces that PRs bump the version when package-affecting files change
+(`src/`, `pyproject.toml`, `README.md`, `LICENSE`, `CHANGELOG.md`).
+PRs that only change tests, CI config, docs, or skills skip the version check.
+Once approved and merged:
 
 ### 4. What Happens Automatically
 
 1. **CI runs** — Lint, type check, and tests on Ubuntu + Windows
 2. **Auto-tag** — CI reads the version from `pyproject.toml` and creates git tag `vX.Y.Z`
-3. **Release pipeline triggers** — The tag triggers `release.yml`:
+3. **Release pipeline triggers** — CI dispatches `release.yml` via `workflow_dispatch`:
    - Lint & test (release validation)
    - Build wheel + sdist
    - Publish to TestPyPI
+   - **Smoke test** — Installs from TestPyPI and verifies import, version, and CLI
    - Publish to PyPI
    - Create GitHub Release with auto-generated notes
 
@@ -102,7 +106,7 @@ This project follows [Semantic Versioning](https://semver.org/):
 - **MINOR** (0.X.0): New features, backward-compatible
 - **PATCH** (0.0.X): Bug fixes, backward-compatible
 
-The CI enforces that every PR to `main` must bump the version.
+The CI enforces that PRs to `main` must bump the version when package-affecting files change.
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.1.2"
+version = "0.1.3"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .database import Database, ParsedQuery, parse_search_query
 from .html_exporter import (

--- a/src/copilot_session_tools/web/__init__.py
+++ b/src/copilot_session_tools/web/__init__.py
@@ -36,14 +36,16 @@ def main():
     import sys
     from pathlib import Path
 
+    _default_db = str(Path.home() / ".copilot-session-tools" / "copilot_chats.db")
+
     parser = argparse.ArgumentParser(
         description="Start the Copilot Chat Archive web server",
     )
     parser.add_argument(
         "--db",
         "-d",
-        default="copilot_chats.db",
-        help="Path to SQLite database file (default: copilot_chats.db)",
+        default=_default_db,
+        help=f"Path to SQLite database file (default: {_default_db})",
     )
     parser.add_argument(
         "--host",

--- a/uv.lock
+++ b/uv.lock
@@ -100,7 +100,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Fixes the auto-tag trigger limitation where GITHUB_TOKEN tags don't trigger other workflows. Adds workflow_dispatch to release.yml and has CI trigger it explicitly. Also changes default DB path to ~/.copilot-session-tools/copilot_chats.db and updates SKILL.md.