### PR TITLE
feat: attribute root custom agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.10.4"
+version = "0.11.0"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.10.4"
+__version__ = "0.11.0"
 
 from .content_types import (
     CONTENT_TYPES,
@@ -40,6 +40,7 @@ from .scanner import (
     CommandRun,
     ContentBlock,
     FileChange,
+    RootAgentInterval,
     ToolInvocation,
     detect_repository_url,
     find_copilot_chat_dirs,
@@ -62,6 +63,7 @@ __all__ = [
     "Database",
     "FileChange",
     "ParsedQuery",
+    "RootAgentInterval",
     "ToolInvocation",
     # Package
     "__version__",

--- a/src/copilot_session_tools/database.py
+++ b/src/copilot_session_tools/database.py
@@ -52,6 +52,7 @@ class Database:
         "cst_command_runs",
         "cst_file_changes",
         "cst_tool_invocations",
+        "cst_root_agent_intervals",
         "cst_messages",
         "cst_sessions",
     ]

--- a/src/copilot_session_tools/db_retrieval.py
+++ b/src/copilot_session_tools/db_retrieval.py
@@ -11,9 +11,10 @@ Extracted from database.py to isolate read-path concerns:
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 
-from .db_schema import row_to_command, row_to_file_change, row_to_tool
+from .db_schema import row_to_command, row_to_file_change, row_to_root_agent_interval, row_to_tool
 from .markdown_exporter import message_to_markdown
 from .scanner import (
     ChatMessage,
@@ -194,6 +195,14 @@ def get_cst_session(conn: sqlite3.Connection, session_id: str) -> ChatSession | 
         block, child_msg_id = _deserialize_content_block(b)
         blocks_by_msg[b["message_id"]].append((block, child_msg_id))
 
+    root_agent_intervals = []
+    with contextlib.suppress(sqlite3.OperationalError):
+        cursor.execute(
+            "SELECT * FROM cst_root_agent_intervals WHERE session_id = ? ORDER BY start_timestamp, id",
+            (session_id,),
+        )
+        root_agent_intervals = [row_to_root_agent_interval(r) for r in cursor.fetchall()]
+
     # --- Reconstruct messages from pre-fetched data ---
     messages_by_id: dict[int, ChatMessage] = {}
     content_block_child_ids: dict[int, dict[int, int]] = {}
@@ -283,6 +292,7 @@ def get_cst_session(conn: sqlite3.Connection, session_id: str) -> ChatSession | 
         source_file_size=safe_get("source_file_size"),
         type=safe_get("type") or "vscode",
         repository_url=safe_get("repository_url"),
+        root_agent_intervals=root_agent_intervals,
     )
 
 

--- a/src/copilot_session_tools/db_schema.py
+++ b/src/copilot_session_tools/db_schema.py
@@ -7,9 +7,10 @@ and read path (db_retrieval.py) reference these constants.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
-from .scanner import ChatSession, CommandRun, FileChange, ToolInvocation
+from .scanner import ChatSession, CommandRun, FileChange, RootAgentInterval, ToolInvocation
 
 # ---------------------------------------------------------------------------
 # Column tuples used in INSERT statements (order matters for parameterized queries)
@@ -98,6 +99,15 @@ CST_CONTENT_BLOCK_COLUMNS = (
     "prompt",
     "is_background",
     "agent_id",
+)
+
+CST_ROOT_AGENT_INTERVAL_COLUMNS = (
+    "session_id",
+    "agent_name",
+    "agent_display_name",
+    "start_timestamp",
+    "end_timestamp",
+    "tools_json",
 )
 
 # ---------------------------------------------------------------------------
@@ -197,6 +207,19 @@ def command_to_row(message_id: int, cmd: CommandRun) -> tuple:
     )
 
 
+def root_agent_interval_to_row(session_id: str, interval: RootAgentInterval) -> tuple:
+    """Map a RootAgentInterval to a parameter tuple matching CST_ROOT_AGENT_INTERVAL_COLUMNS."""
+    tools_json = json.dumps(interval.tools) if interval.tools is not None else None
+    return (
+        session_id,
+        interval.agent_name,
+        interval.agent_display_name,
+        interval.start_timestamp,
+        interval.end_timestamp,
+        tools_json,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Row → dataclass helpers  (read path)
 # ---------------------------------------------------------------------------
@@ -219,6 +242,23 @@ def row_to_tool(row: sqlite3.Row) -> ToolInvocation:
         backlink_agent_id=row["backlink_agent_id"] if "backlink_agent_id" in keys else None,
         is_shell_backlink=bool(row["is_shell_backlink"]) if "is_shell_backlink" in keys and row["is_shell_backlink"] else False,
         backlink_shell_id=row["backlink_shell_id"] if "backlink_shell_id" in keys else None,
+    )
+
+
+def row_to_root_agent_interval(row: sqlite3.Row) -> RootAgentInterval:
+    """Map a cst_root_agent_intervals row to a RootAgentInterval."""
+    tools_json = row["tools_json"] if "tools_json" in row.keys() else None  # noqa: SIM118
+    tools = None
+    if tools_json:
+        parsed_tools = json.loads(tools_json)
+        if isinstance(parsed_tools, list):
+            tools = [str(tool) for tool in parsed_tools]
+    return RootAgentInterval(
+        agent_name=row["agent_name"],
+        agent_display_name=row["agent_display_name"],
+        start_timestamp=row["start_timestamp"],
+        end_timestamp=row["end_timestamp"],
+        tools=tools,
     )
 
 

--- a/src/copilot_session_tools/db_storage.py
+++ b/src/copilot_session_tools/db_storage.py
@@ -16,18 +16,20 @@ from .db_schema import (
     CST_CONTENT_BLOCK_COLUMNS,
     CST_FILE_CHANGE_COLUMNS,
     CST_MESSAGE_COLUMNS,
+    CST_ROOT_AGENT_INTERVAL_COLUMNS,
     CST_SESSION_COLUMNS,
     CST_TOOL_INVOCATION_COLUMNS,
     command_to_row,
     file_change_to_row,
     insert_sql,
+    root_agent_interval_to_row,
     session_to_row,
     tool_to_row,
 )
 from .markdown_exporter import message_to_markdown
 from .scanner import ChatSession
 
-CST_SCHEMA_VERSION = 8
+CST_SCHEMA_VERSION = 9
 
 
 CST_SCHEMA = """
@@ -133,6 +135,18 @@ CREATE TABLE IF NOT EXISTS cst_content_blocks (
 );
 CREATE INDEX IF NOT EXISTS idx_cst_content_blocks_message ON cst_content_blocks(message_id);
 
+CREATE TABLE IF NOT EXISTS cst_root_agent_intervals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES cst_sessions(session_id) ON DELETE CASCADE,
+    agent_name TEXT NOT NULL,
+    agent_display_name TEXT NOT NULL,
+    start_timestamp TEXT NOT NULL,
+    end_timestamp TEXT,
+    tools_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_cst_root_agent_intervals_session ON cst_root_agent_intervals(session_id, start_timestamp);
+CREATE INDEX IF NOT EXISTS idx_cst_root_agent_intervals_agent ON cst_root_agent_intervals(agent_name);
+
 CREATE VIEW IF NOT EXISTS cst_messages_tree AS
 SELECT
     m.id,
@@ -176,6 +190,57 @@ SELECT
     (SELECT COUNT(*) FROM cst_content_blocks cb WHERE cb.message_id = m.id) as content_block_count
 FROM cst_messages m
 WHERE m.parent_message_id IS NOT NULL;
+
+CREATE VIEW IF NOT EXISTS cst_root_agent_messages AS
+SELECT
+    i.id as interval_id,
+    i.session_id,
+    i.agent_name,
+    i.agent_display_name,
+    i.start_timestamp,
+    i.end_timestamp,
+    m.id as message_id,
+    m.message_index,
+    m.role,
+    m.timestamp,
+    m.content
+FROM cst_root_agent_intervals i
+JOIN cst_messages m
+    ON m.session_id = i.session_id
+    AND m.timestamp >= i.start_timestamp
+    AND (i.end_timestamp IS NULL OR m.timestamp < i.end_timestamp);
+
+CREATE VIEW IF NOT EXISTS cst_root_agent_tool_invocations AS
+SELECT
+    rm.interval_id,
+    rm.session_id,
+    rm.agent_name,
+    rm.agent_display_name,
+    rm.start_timestamp,
+    rm.end_timestamp,
+    t.id as tool_id,
+    t.name,
+    t.input,
+    t.result,
+    t.status,
+    t.invocation_message,
+    rm.message_id,
+    rm.message_index,
+    rm.role,
+    rm.timestamp
+FROM cst_root_agent_messages rm
+JOIN cst_tool_invocations t ON t.message_id = rm.message_id;
+
+CREATE VIEW IF NOT EXISTS cst_root_agent_usage AS
+SELECT
+    i.agent_name,
+    MAX(i.agent_display_name) as agent_display_name,
+    COUNT(*) as run_count,
+    COUNT(DISTINCT i.session_id) as session_count,
+    (SELECT COUNT(*) FROM cst_root_agent_messages rm WHERE rm.agent_name = i.agent_name) as message_count,
+    (SELECT COUNT(*) FROM cst_root_agent_tool_invocations rt WHERE rt.agent_name = i.agent_name) as tool_count
+FROM cst_root_agent_intervals i
+GROUP BY i.agent_name;
 """
 
 CST_FTS_SCHEMA = """
@@ -216,7 +281,7 @@ def _drop_and_recreate_cst_tables(conn: sqlite3.Connection) -> None:
     """
     cursor = conn.cursor()
     # Drop views before tables
-    for view in ["cst_messages_tree", "cst_all_tool_invocations", "cst_subagent_summary"]:
+    for view in ["cst_root_agent_usage", "cst_root_agent_tool_invocations", "cst_root_agent_messages", "cst_messages_tree", "cst_all_tool_invocations", "cst_subagent_summary"]:
         cursor.execute(f"DROP VIEW IF EXISTS {view}")
     # Drop in reverse dependency order
     for table in [
@@ -225,6 +290,7 @@ def _drop_and_recreate_cst_tables(conn: sqlite3.Connection) -> None:
         "cst_command_runs",
         "cst_file_changes",
         "cst_tool_invocations",
+        "cst_root_agent_intervals",
         "cst_messages",
         "cst_sessions",
         "cst_schema_version",
@@ -251,6 +317,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     # Check if schema already exists and needs migration BEFORE creating tables.
     # This is critical for v6+ because CST_SCHEMA includes views that reference
     # new columns — running it against a v5 table would fail.
+    current_version = 0
     needs_migration = False
     try:
         cursor.execute("SELECT COUNT(*) FROM cst_schema_version")
@@ -296,6 +363,9 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             for col in ("is_shell_backlink INTEGER DEFAULT 0", "backlink_shell_id TEXT"):
                 with contextlib.suppress(sqlite3.OperationalError):
                     cursor.execute(f"ALTER TABLE cst_tool_invocations ADD COLUMN {col}")
+        # v8 → v9: Add root custom-agent interval storage and views.
+        if current_version < 9:
+            conn.executescript(CST_SCHEMA)
         cursor.execute(
             "UPDATE cst_schema_version SET version = ?",
             (CST_SCHEMA_VERSION,),
@@ -420,7 +490,15 @@ def _delete_session_data(cursor: sqlite3.Cursor, session_id: str) -> None:
         (session_id,),
     )
     cursor.execute("DELETE FROM cst_messages_fts WHERE session_id = ?", (session_id,))
+    cursor.execute("DELETE FROM cst_root_agent_intervals WHERE session_id = ?", (session_id,))
     cursor.execute("DELETE FROM cst_messages WHERE session_id = ?", (session_id,))
+
+
+def _require_lastrowid(cursor: sqlite3.Cursor, table_name: str) -> int:
+    row_id = cursor.lastrowid
+    if row_id is None:
+        raise sqlite3.DatabaseError(f"Failed to insert row into {table_name}: SQLite did not return a row id")
+    return row_id
 
 
 def add_session(conn: sqlite3.Connection, session: ChatSession) -> bool:
@@ -497,7 +575,7 @@ def _insert_content_blocks_recursive(
                     block_idx,  # child_index = block position for ordering
                 ),
             )
-            child_message_id = cursor.lastrowid
+            child_message_id = _require_lastrowid(cursor, "cst_messages")
 
             # Insert child's artifacts
             for tool in child.tool_invocations:
@@ -545,6 +623,12 @@ def add_session_impl(cursor: sqlite3.Cursor, session: ChatSession) -> None:
         session_to_row(session, enrichment_version=__version__),
     )
 
+    for interval in session.root_agent_intervals:
+        cursor.execute(
+            insert_sql("cst_root_agent_intervals", CST_ROOT_AGENT_INTERVAL_COLUMNS),
+            root_agent_interval_to_row(session.session_id, interval),
+        )
+
     # Insert messages and related data
     for idx, msg in enumerate(session.messages):
         cached_markdown = message_to_markdown(
@@ -570,7 +654,7 @@ def add_session_impl(cursor: sqlite3.Cursor, session: ChatSession) -> None:
                 msg.child_index,
             ),
         )
-        message_id = cursor.lastrowid
+        message_id = _require_lastrowid(cursor, "cst_messages")
 
         # Insert tool invocations
         for tool in msg.tool_invocations:
@@ -836,6 +920,12 @@ def enrich_session(conn: sqlite3.Connection, session: ChatSession) -> None:
         session_to_row(session, enrichment_version=__version__, updated_at_fallback=enriched_at),
     )
 
+    for interval in session.root_agent_intervals:
+        cursor.execute(
+            insert_sql("cst_root_agent_intervals", CST_ROOT_AGENT_INTERVAL_COLUMNS),
+            root_agent_interval_to_row(session.session_id, interval),
+        )
+
     # Insert messages and related data
     for idx, msg in enumerate(session.messages):
         cached_markdown = message_to_markdown(
@@ -861,7 +951,7 @@ def enrich_session(conn: sqlite3.Connection, session: ChatSession) -> None:
                 msg.child_index,
             ),
         )
-        message_id = cursor.lastrowid
+        message_id = _require_lastrowid(cursor, "cst_messages")
 
         # Insert content blocks (recursive for nested subagent children)
         _insert_content_blocks_recursive(

--- a/src/copilot_session_tools/html_exporter.py
+++ b/src/copilot_session_tools/html_exporter.py
@@ -12,6 +12,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from .scanner import ChatSession
 from .utils import (
     build_block_metadata,
+    build_root_agent_markers,
     detect_language,
     extract_filename,
     format_timestamp,
@@ -113,6 +114,7 @@ def session_to_html(session: ChatSession, content_set: set[str] | None = None) -
         message_count=len(session.messages),
         first_user_prompt=first_user_prompt,
         message_metadata=message_metadata,
+        root_agent_markers=build_root_agent_markers(session),
         static=True,
         is_enriched=True,
         include_agent_details=include_agent_details,

--- a/src/copilot_session_tools/refresh.py
+++ b/src/copilot_session_tools/refresh.py
@@ -143,7 +143,7 @@ def _classify_and_batch_write(
     return added, updated
 
 
-def _parse_cli_entry(entry: dict) -> tuple[str, ChatSession | str | None]:
+def _parse_cli_entry(entry: dict) -> tuple[str, ChatSession | str]:
     """Parse a single CLI session's ``events.jsonl``.  Runs in a worker process.
 
     Must be at module level for :class:`ProcessPoolExecutor` pickling on
@@ -172,7 +172,7 @@ def _enrich_session_batch(
     stamp_version_on_failure: bool = False,
     on_progress: ProgressCallback | None = None,
     skip_ids: set[str] | None = None,
-    executor: ProcessPoolExecutor | None = None,
+    executor: ProcessPoolExecutor,
 ) -> tuple[int, int]:
     """Enrich a batch of sessions, handling errors and version stamping.
 

--- a/src/copilot_session_tools/scanner/__init__.py
+++ b/src/copilot_session_tools/scanner/__init__.py
@@ -5,7 +5,7 @@ Data structures are informed by:
 - microsoft/vscode-copilot-chat (https://github.com/microsoft/vscode-copilot-chat)
 """
 
-PARSER_VERSION = 3
+PARSER_VERSION = 4
 
 from .cli import _parse_cli_jsonl_file, _parse_workspace_yaml
 from .content import (
@@ -32,6 +32,7 @@ from .models import (
     CommandRun,
     ContentBlock,
     FileChange,
+    RootAgentInterval,
     SessionFileInfo,
     ToolInvocation,
 )
@@ -58,6 +59,7 @@ __all__ = [
     "CommandRun",
     "ContentBlock",
     "FileChange",
+    "RootAgentInterval",
     "SessionFileInfo",
     "ToolInvocation",
     "_apply_jsonl_operations",

--- a/src/copilot_session_tools/scanner/cli.py
+++ b/src/copilot_session_tools/scanner/cli.py
@@ -14,6 +14,7 @@ from .models import (
     ChatSession,
     CommandRun,
     ContentBlock,
+    RootAgentInterval,
     ShellIOEntry,
     ToolInvocation,
 )
@@ -439,6 +440,8 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
 
         # Build tool execution map: toolCallId -> (start_data, complete_data, user_requested)
         tool_executions: dict = {}
+        root_agent_intervals: list[RootAgentInterval] = []
+        active_root_agent: RootAgentInterval | None = None
         # Map parent agent toolCallId -> list of child tool display names
         subagent_child_tools: dict[str, list[str]] = {}
         # Map parent agent toolCallId -> list of (ToolInvocation | None, CommandRun | None, content_blocks)
@@ -458,6 +461,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
         for event in events:
             event_type = event.get("type", "")
             event_data = event.get("data", {})
+            timestamp = event.get("timestamp")
 
             if event_type == "tool.execution_start":
                 tool_call_id = event_data.get("toolCallId")
@@ -538,6 +542,31 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 tool_call_id = event_data.get("toolCallId", "")
                 if tool_call_id:
                     subagent_completions.add(tool_call_id)
+
+            elif event_type == "subagent.selected":
+                if timestamp is None:
+                    continue
+                if active_root_agent is not None:
+                    active_root_agent.end_timestamp = timestamp
+                    root_agent_intervals.append(active_root_agent)
+                agent_name = event_data.get("agentName") or event_data.get("agentDisplayName") or "unknown"
+                agent_display_name = event_data.get("agentDisplayName") or agent_name
+                tools = event_data.get("tools")
+                active_root_agent = RootAgentInterval(
+                    agent_name=agent_name,
+                    agent_display_name=agent_display_name,
+                    start_timestamp=timestamp,
+                    tools=tools if isinstance(tools, list) else None,
+                )
+
+            elif event_type == "subagent.deselected":
+                if active_root_agent is not None:
+                    active_root_agent.end_timestamp = timestamp
+                    root_agent_intervals.append(active_root_agent)
+                    active_root_agent = None
+
+        if active_root_agent is not None:
+            root_agent_intervals.append(active_root_agent)
 
         # Infer subagent completion from tool.execution_complete when no
         # explicit subagent.completed event was emitted (common in older CLI versions)
@@ -765,12 +794,12 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 # Detect background agent (even for failed ones)
                 is_bg = tool_call_id in builder.bg_agent_id_map
                 bg_id = builder.bg_agent_id_map.get(tool_call_id, "")
+                result_text = ""
                 if failed:
                     error = builder.subagent_failures[tool_call_id]
                     parts.append(f"**Error:** {error}" if error else "**Error:** Unknown error")
                 else:
                     # Get the agent's result — check for background agent placeholder
-                    result_text = ""
                     execution = builder.tool_executions.get(tool_call_id, {})
                     complete_event = execution.get("complete")
                     if complete_event:
@@ -1001,9 +1030,6 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 # Streaming tool events (partial results, final is in tool.execution_complete)
                 "tool.execution_partial_result",
                 "tool.execution_progress",
-                # Agent selection (routing metadata)
-                "subagent.selected",
-                "subagent.deselected",
             ):
                 pass
 
@@ -1117,6 +1143,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
             source_file_size=source_file_size,
             type="cli",
             repository_url=repository_url,
+            root_agent_intervals=root_agent_intervals,
         )
         session.parser_version = PARSER_VERSION
         return session

--- a/src/copilot_session_tools/scanner/models.py
+++ b/src/copilot_session_tools/scanner/models.py
@@ -126,6 +126,17 @@ class ChatMessage:
 
 
 @dataclass
+class RootAgentInterval:
+    """Represents a root custom-agent selection interval in a CLI session."""
+
+    agent_name: str
+    agent_display_name: str
+    start_timestamp: str
+    end_timestamp: str | None = None
+    tools: list[str] | None = None
+
+
+@dataclass
 class ChatSession:
     """Represents a Copilot chat session.
 
@@ -149,6 +160,7 @@ class ChatSession:
     repository_url: str | None = None  # Git remote URL for repository-scoped memories
     parser_version: int = 1
     source_format: str | None = None  # 'cli', 'json', 'jsonl', 'vscdb'
+    root_agent_intervals: list[RootAgentInterval] = field(default_factory=list)
 
 
 @dataclass

--- a/src/copilot_session_tools/utils.py
+++ b/src/copilot_session_tools/utils.py
@@ -14,11 +14,11 @@ from urllib.parse import unquote
 import markdown
 from markupsafe import Markup
 from pygments import highlight as _pygments_highlight
-from pygments.formatters import HtmlFormatter as _HtmlFormatter
-from pygments.lexers import DiffLexer as _DiffLexer
-from pygments.lexers import JsonLexer as _JsonLexer
-from pygments.lexers import TextLexer as _TextLexer
+from pygments.formatters.html import HtmlFormatter as _HtmlFormatter
 from pygments.lexers import get_lexer_by_name as _get_lexer_by_name
+from pygments.lexers.data import JsonLexer as _JsonLexer
+from pygments.lexers.diff import DiffLexer as _DiffLexer
+from pygments.lexers.special import TextLexer as _TextLexer
 from pygments.util import ClassNotFound as _ClassNotFound
 
 from .scanner import ChatSession
@@ -32,6 +32,40 @@ MILLISECONDS_THRESHOLD = 1e12
 
 DEFAULT_DB_DIR = Path.home() / ".copilot"
 """Directory containing the session-store database."""
+
+
+def _first_message_index_at_or_after(session: ChatSession, timestamp: str) -> int:
+    """Find the first top-level message at or after an ISO timestamp."""
+    for index, message in enumerate(session.messages):
+        if message.timestamp and message.timestamp >= timestamp:
+            return index
+    return len(session.messages)
+
+
+def build_root_agent_markers(session: ChatSession) -> dict[int, list[dict[str, str]]]:
+    """Build transcript timeline markers for root custom-agent transitions."""
+    markers: dict[int, list[dict[str, str]]] = {}
+    start_timestamps = {interval.start_timestamp for interval in session.root_agent_intervals}
+    for interval in session.root_agent_intervals:
+        start_index = _first_message_index_at_or_after(session, interval.start_timestamp)
+        markers.setdefault(start_index, []).append(
+            {
+                "kind": "enter",
+                "label": f"Entered {interval.agent_display_name or interval.agent_name}",
+                "timestamp": interval.start_timestamp,
+            }
+        )
+        if interval.end_timestamp and interval.end_timestamp not in start_timestamps:
+            end_index = _first_message_index_at_or_after(session, interval.end_timestamp)
+            markers.setdefault(end_index, []).append(
+                {
+                    "kind": "default",
+                    "label": "Back to default",
+                    "timestamp": interval.end_timestamp,
+                }
+            )
+    return markers
+
 
 DEFAULT_DB_PATH = DEFAULT_DB_DIR / "copilot-session-tools.db"
 """Default path to the copilot-session-tools enrichment database."""

--- a/src/copilot_session_tools/web/templates/session.html
+++ b/src/copilot_session_tools/web/templates/session.html
@@ -631,6 +631,33 @@ header h1 {
     margin: 4px 0;
 }
 
+{%- if root_agent_markers is defined and root_agent_markers %}
+.root-agent-marker {
+    display: flex;
+    justify-content: flex-start;
+    margin: 10px 0 10px 12px;
+}
+
+.root-agent-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border-radius: 999px;
+    border: 1px solid rgba(124, 58, 237, 0.35);
+    background: rgba(124, 58, 237, 0.12);
+    color: #6d28d9;
+    font-size: 0.85em;
+    font-weight: 600;
+}
+
+.root-agent-pill.default {
+    border-color: var(--border-color);
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+}
+{%- endif %}
+
 .status-badge.model-change {
     background-color: rgba(107, 114, 128, 0.15);
     color: #6b7280;
@@ -658,6 +685,13 @@ header h1 {
         background-color: rgba(248, 113, 113, 0.2);
         color: #f87171;
     }
+{%- if root_agent_markers is defined and root_agent_markers %}
+    .root-agent-pill {
+        border-color: rgba(167, 139, 250, 0.45);
+        background: rgba(124, 58, 237, 0.2);
+        color: #c4b5fd;
+    }
+{%- endif %}
 }
 
 /* Failed subagent collapsible */
@@ -3281,6 +3315,15 @@ input:checked + .toggle-switch::after {
 
         <div class="messages">
             {% for message in session.messages %}
+            {%- if root_agent_markers is defined and root_agent_markers %}
+            {% for marker in root_agent_markers.get(loop.index0, []) %}
+            <div class="root-agent-marker">
+                <span class="root-agent-pill {{ marker.kind }}" title="{{ marker.timestamp | format_timestamp }}">
+                    {% if marker.kind == 'enter' %}🤖{% else %}↩{% endif %} {{ marker.label }}
+                </span>
+            </div>
+            {% endfor %}
+            {%- endif %}
             {% set msg_meta = message_metadata.get(loop.index0, {}) %}
             {% set is_system_notification = message.role == 'user' and message.content.strip().startswith('<system_notification>') and 'agent' in message.content.lower() and ('completed' in message.content.lower() or 'failed' in message.content.lower()) %}
             {% if is_system_notification %}
@@ -3337,6 +3380,15 @@ input:checked + .toggle-switch::after {
             </div>
             {% endif %}
             {% endfor %}
+            {%- if root_agent_markers is defined and root_agent_markers %}
+            {% for marker in root_agent_markers.get(session.messages | length, []) %}
+            <div class="root-agent-marker">
+                <span class="root-agent-pill {{ marker.kind }}" title="{{ marker.timestamp | format_timestamp }}">
+                    {% if marker.kind == 'enter' %}🤖{% else %}↩{% endif %} {{ marker.label }}
+                </span>
+            </div>
+            {% endfor %}
+            {%- endif %}
         </div>
         {%- if new_turns %}
         <div class="unenriched-banner" style="margin-top: 24px;">

--- a/src/copilot_session_tools/web/webapp.py
+++ b/src/copilot_session_tools/web/webapp.py
@@ -11,6 +11,7 @@ from copilot_session_tools.html_exporter import generate_session_html_filename, 
 from copilot_session_tools.refresh import enrich_single_session, run_enrichment, run_refresh
 from copilot_session_tools.utils import (
     build_block_metadata,
+    build_root_agent_markers,
     detect_language,
     extract_filename,
     format_timestamp,
@@ -343,6 +344,7 @@ def create_app(
             message_count=len(session.messages),
             first_user_prompt=first_user_prompt,
             message_metadata=message_metadata,
+            root_agent_markers=build_root_agent_markers(session) if is_enriched else {},
             is_enriched=is_enriched,
             turns=turns,
             new_turns=new_turns,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from copilot_session_tools import ChatMessage, ChatSession, CommandRun, ContentBlock, Database, FileChange, ToolInvocation, parse_search_query
+from copilot_session_tools.scanner import RootAgentInterval
 
 
 @pytest.fixture
@@ -86,6 +87,192 @@ class TestDatabase:
         assert len(retrieved.messages) == len(sample_session.messages)
         assert retrieved.messages[0].role == "user"
         assert "Python function" in retrieved.messages[0].content
+
+    def test_root_agent_intervals_persist_and_retrieve(self, temp_db):
+        """Test root custom-agent intervals persist and hydrate with sessions."""
+        session = ChatSession(
+            session_id="root-agent-session",
+            workspace_name="test-project",
+            workspace_path="/test",
+            messages=[
+                ChatMessage(role="user", content="Merge main", timestamp="2026-01-01T00:00:02Z"),
+                ChatMessage(
+                    role="assistant",
+                    content="Starting merge.",
+                    timestamp="2026-01-01T00:00:03Z",
+                    tool_invocations=[
+                        ToolInvocation(
+                            name="report_intent",
+                            input='{"intent": "Merging upstream"}',
+                            result="ok",
+                            status="success",
+                        )
+                    ],
+                ),
+                ChatMessage(role="assistant", content="Back to default.", timestamp="2026-01-01T00:00:05Z"),
+            ],
+            root_agent_intervals=[
+                RootAgentInterval(
+                    agent_name="smart-merge",
+                    agent_display_name="Smart Merge",
+                    start_timestamp="2026-01-01T00:00:01Z",
+                    end_timestamp="2026-01-01T00:00:04Z",
+                    tools=["report_intent", "powershell"],
+                )
+            ],
+        )
+
+        temp_db.add_session(session)
+
+        retrieved = temp_db.get_session("root-agent-session")
+        assert retrieved is not None
+        assert retrieved.root_agent_intervals == session.root_agent_intervals
+
+        with temp_db._get_connection() as conn:
+            row = conn.execute(
+                "SELECT agent_name, tools_json FROM cst_root_agent_intervals WHERE session_id = ?",
+                ("root-agent-session",),
+            ).fetchone()
+            assert row["agent_name"] == "smart-merge"
+            assert json.loads(row["tools_json"]) == ["report_intent", "powershell"]
+
+            messages = conn.execute(
+                "SELECT content FROM cst_root_agent_messages WHERE session_id = ? ORDER BY message_index",
+                ("root-agent-session",),
+            ).fetchall()
+            assert [row["content"] for row in messages] == ["Merge main", "Starting merge."]
+
+            usage = conn.execute("SELECT * FROM cst_root_agent_usage WHERE agent_name = ?", ("smart-merge",)).fetchone()
+            assert usage["run_count"] == 1
+            assert usage["session_count"] == 1
+            assert usage["message_count"] == 2
+            assert usage["tool_count"] == 1
+
+    def test_root_agent_views_include_nested_subagent_activity(self, temp_db):
+        """Root-agent usage includes child subagent work inside the interval."""
+        session = ChatSession(
+            session_id="root-agent-nested-session",
+            workspace_name="test-project",
+            workspace_path="/test",
+            messages=[
+                ChatMessage(
+                    role="assistant",
+                    content="Launching review.",
+                    timestamp="2026-01-01T00:00:02Z",
+                    tool_invocations=[
+                        ToolInvocation(
+                            name="task",
+                            input='{"agent_type": "code-review"}',
+                            result="started",
+                            status="success",
+                        )
+                    ],
+                    content_blocks=[
+                        ContentBlock(
+                            kind="subagent",
+                            content="Review result",
+                            description="code-review",
+                            child_message=ChatMessage(
+                                role="assistant",
+                                content="Reviewed file.",
+                                timestamp="2026-01-01T00:00:03Z",
+                                agent_id="tc1",
+                                agent_display_name="code-review",
+                                agent_nesting_level=1,
+                                tool_invocations=[
+                                    ToolInvocation(
+                                        name="view",
+                                        input='{"path": "src/example.py"}',
+                                        result="ok",
+                                        status="success",
+                                    )
+                                ],
+                            ),
+                        )
+                    ],
+                )
+            ],
+            root_agent_intervals=[
+                RootAgentInterval(
+                    agent_name="smart-merge",
+                    agent_display_name="Smart Merge",
+                    start_timestamp="2026-01-01T00:00:01Z",
+                    end_timestamp="2026-01-01T00:00:04Z",
+                )
+            ],
+        )
+
+        temp_db.add_session(session)
+
+        with temp_db._get_connection() as conn:
+            messages = conn.execute(
+                "SELECT content FROM cst_root_agent_messages WHERE session_id = ? ORDER BY timestamp, message_id",
+                ("root-agent-nested-session",),
+            ).fetchall()
+            tools = conn.execute(
+                "SELECT name FROM cst_root_agent_tool_invocations WHERE session_id = ? ORDER BY timestamp, tool_id",
+                ("root-agent-nested-session",),
+            ).fetchall()
+            usage = conn.execute("SELECT * FROM cst_root_agent_usage WHERE agent_name = ?", ("smart-merge",)).fetchone()
+
+        assert [row["content"] for row in messages] == ["Launching review.", "Reviewed file."]
+        assert [row["name"] for row in tools] == ["task", "view"]
+        assert usage["message_count"] == 2
+        assert usage["tool_count"] == 2
+
+    def test_root_agent_intervals_are_deleted_with_session_refresh(self, temp_db):
+        """Replacing a session clears stale root-agent intervals."""
+        session = ChatSession(
+            session_id="refresh-root-agent-session",
+            workspace_name="test-project",
+            workspace_path="/test",
+            messages=[ChatMessage(role="user", content="Initial", timestamp="2026-01-01T00:00:02Z")],
+            root_agent_intervals=[
+                RootAgentInterval(
+                    agent_name="smart-merge",
+                    agent_display_name="Smart Merge",
+                    start_timestamp="2026-01-01T00:00:01Z",
+                )
+            ],
+        )
+        temp_db.add_session(session)
+
+        refreshed = ChatSession(
+            session_id="refresh-root-agent-session",
+            workspace_name="test-project",
+            workspace_path="/test",
+            messages=[ChatMessage(role="user", content="Refreshed", timestamp="2026-01-01T00:01:02Z")],
+        )
+        temp_db.update_session(refreshed)
+
+        retrieved = temp_db.get_session("refresh-root-agent-session")
+        assert retrieved is not None
+        assert retrieved.root_agent_intervals == []
+
+    def test_root_agent_intervals_persist_through_enrichment_path(self, temp_db):
+        """Test scanner enrichment writes root custom-agent intervals."""
+        session = ChatSession(
+            session_id="enrich-root-agent-session",
+            workspace_name="test-project",
+            workspace_path="/test",
+            messages=[ChatMessage(role="user", content="Audit skills", timestamp="2026-01-01T00:00:02Z")],
+            root_agent_intervals=[
+                RootAgentInterval(
+                    agent_name="skill-audit",
+                    agent_display_name="Skill Audit",
+                    start_timestamp="2026-01-01T00:00:01Z",
+                )
+            ],
+        )
+
+        temp_db.enrich_session(session)
+
+        with temp_db._get_connection() as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM cst_root_agent_intervals WHERE session_id = ?",
+                ("enrich-root-agent-session",),
+            ).fetchone()[0]
+            assert count == 1
 
     def test_get_nonexistent_session(self, temp_db):
         """Test that getting a nonexistent session returns None."""

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -13,6 +13,7 @@ from copilot_session_tools import (
     ChatSession,
     CommandRun,
     FileChange,
+    RootAgentInterval,
     ToolInvocation,
     find_copilot_chat_dirs,
     scan_chat_sessions,
@@ -1348,6 +1349,115 @@ class TestCLINewEventHandlers:
             assert msg.agent_id is None
             assert msg.agent_display_name is None
             assert msg.agent_nesting_level == 0
+
+    # --- root custom-agent intervals ---
+
+    def test_root_agent_selection_creates_interval(self, tmp_path):
+        """subagent.selected records a root custom-agent interval without changing message metadata."""
+        session = self._parse(
+            tmp_path,
+            {
+                "type": "subagent.selected",
+                "timestamp": "2026-01-01T00:00:01Z",
+                "data": {"agentName": "smart-merge", "agentDisplayName": "smart-merge", "tools": ["sql", "powershell"]},
+            },
+            {"type": "user.message", "timestamp": "2026-01-01T00:00:02Z", "data": {"content": "Merge main"}},
+            {"type": "assistant.message", "timestamp": "2026-01-01T00:00:03Z", "data": {"content": "Starting merge."}},
+            {"type": "subagent.deselected", "timestamp": "2026-01-01T00:00:04Z", "data": {}},
+            {"type": "assistant.message", "timestamp": "2026-01-01T00:00:05Z", "data": {"content": "Back to default."}},
+        )
+
+        assert session is not None
+        assert session.root_agent_intervals == [
+            RootAgentInterval(
+                agent_name="smart-merge",
+                agent_display_name="smart-merge",
+                start_timestamp="2026-01-01T00:00:01Z",
+                end_timestamp="2026-01-01T00:00:04Z",
+                tools=["sql", "powershell"],
+            )
+        ]
+        assert [msg.agent_display_name for msg in session.messages] == [None, None]
+
+    def test_root_agent_reselection_closes_previous_interval(self, tmp_path):
+        """A new subagent.selected closes the previous root-agent interval."""
+        session = self._parse(
+            tmp_path,
+            {
+                "type": "subagent.selected",
+                "timestamp": "2026-01-01T00:00:01Z",
+                "data": {"agentName": "smart-merge", "agentDisplayName": "Smart Merge"},
+            },
+            {"type": "user.message", "timestamp": "2026-01-01T00:00:02Z", "data": {"content": "Merge main"}},
+            {
+                "type": "subagent.selected",
+                "timestamp": "2026-01-01T00:00:03Z",
+                "data": {"agentName": "skill-audit", "agentDisplayName": "Skill Audit"},
+            },
+            {"type": "assistant.message", "timestamp": "2026-01-01T00:00:04Z", "data": {"content": "Auditing."}},
+        )
+
+        assert session is not None
+        assert session.root_agent_intervals == [
+            RootAgentInterval(
+                agent_name="smart-merge",
+                agent_display_name="Smart Merge",
+                start_timestamp="2026-01-01T00:00:01Z",
+                end_timestamp="2026-01-01T00:00:03Z",
+            ),
+            RootAgentInterval(
+                agent_name="skill-audit",
+                agent_display_name="Skill Audit",
+                start_timestamp="2026-01-01T00:00:03Z",
+            ),
+        ]
+
+    def test_root_agent_selection_without_timestamp_is_ignored(self, tmp_path):
+        """A root-agent interval needs a timestamp anchor."""
+        session = self._parse(
+            tmp_path,
+            {"type": "subagent.selected", "data": {"agentName": "smart-merge", "agentDisplayName": "Smart Merge"}},
+            {"type": "user.message", "timestamp": "2026-01-01T00:00:02Z", "data": {"content": "Merge main"}},
+        )
+
+        assert session is not None
+        assert session.root_agent_intervals == []
+
+    def test_root_agent_selection_does_not_affect_nested_subagent_handling(self, tmp_path):
+        """Root-agent intervals stay separate from spawned task subagent records."""
+        session = self._parse(
+            tmp_path,
+            {
+                "type": "subagent.selected",
+                "timestamp": "2026-01-01T00:00:01Z",
+                "data": {"agentName": "smart-merge", "agentDisplayName": "smart-merge"},
+            },
+            {"type": "assistant.message", "timestamp": "2026-01-01T00:00:02Z", "data": {"content": "Spawning explorer."}},
+            {
+                "type": "tool.execution_start",
+                "timestamp": "2026-01-01T00:00:03Z",
+                "data": {"toolCallId": "tc1", "toolName": "task", "arguments": {"agent_type": "explore"}},
+            },
+            {"type": "subagent.started", "timestamp": "2026-01-01T00:00:03Z", "data": {"toolCallId": "tc1", "agentDisplayName": "explore"}},
+            {
+                "type": "tool.execution_start",
+                "timestamp": "2026-01-01T00:00:04Z",
+                "data": {"toolCallId": "child1", "toolName": "view", "parentToolCallId": "tc1", "arguments": {"path": "README.md"}},
+            },
+            {
+                "type": "tool.execution_complete",
+                "timestamp": "2026-01-01T00:00:05Z",
+                "data": {"toolCallId": "tc1", "success": True, "result": {"content": "Found the answer"}},
+            },
+            {"type": "subagent.completed", "timestamp": "2026-01-01T00:00:05Z", "data": {"toolCallId": "tc1", "agentDisplayName": "explore"}},
+        )
+
+        assert session is not None
+        assert len(session.root_agent_intervals) == 1
+        subagent_blocks = [block for msg in session.messages for block in msg.content_blocks if block.kind == "subagent"]
+        assert len(subagent_blocks) == 1
+        assert subagent_blocks[0].child_message is not None
+        assert subagent_blocks[0].child_message.agent_display_name == "explore"
 
     # --- subagent.completed (emits subagent content block) ---
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -397,6 +397,7 @@ class TestBacklinkStateRendering:
         f = tmp_path / "events.jsonl"
         f.write_text(self._make_events(*events), encoding="utf-8")
         session = _parse_cli_jsonl_file(f)
+        assert session is not None
         return session_to_html(session)
 
     def test_running_agent_gets_in_progress_class(self, tmp_path):
@@ -425,6 +426,7 @@ class TestBacklinkStateRendering:
         f = tmp_path / "events.jsonl"
         f.write_text(self._make_events(*events), encoding="utf-8")
         session = _parse_cli_jsonl_file(f)
+        assert session is not None
         html = session_to_html(session)
         # The CSS class may exist in stylesheet, but no element should use it
         assert '<span class="subagent-started">' not in html
@@ -543,6 +545,7 @@ class TestAsyncShellRendering:
         f = tmp_path / "events.jsonl"
         f.write_text(self._make_events(*events), encoding="utf-8")
         session = _parse_cli_jsonl_file(f)
+        assert session is not None
         return session_to_html(session)
 
     def test_async_shell_renders_with_amber_class(self, tmp_path):

--- a/tests/test_transcript_cleanup.py
+++ b/tests/test_transcript_cleanup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -9,16 +10,16 @@ import pytest
 from copilot_session_tools.scanner.models import ChatMessage, ChatSession, ContentBlock, ToolInvocation
 
 
-def _make_test_session(**kwargs) -> ChatSession:
+def _make_test_session(**kwargs: Any) -> ChatSession:
     """Helper to create ChatSession with sensible defaults for tests."""
-    defaults = {
+    defaults: dict[str, Any] = {
         "session_id": "test-session",
         "workspace_name": "test-workspace",
         "workspace_path": "/test/workspace",
         "messages": [],
     }
     defaults.update(kwargs)
-    return ChatSession(**defaults)  # ty: ignore[call-non-callable]
+    return ChatSession(**defaults)
 
 
 from copilot_session_tools.transcript_cleanup import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from copilot_session_tools.scanner.models import (
+    ChatMessage,
     ChatSession,
     CommandRun,
     ContentBlock,
+    RootAgentInterval,
     ToolInvocation,
 )
 from copilot_session_tools.utils import (
     MILLISECONDS_THRESHOLD,
     build_block_metadata,
+    build_root_agent_markers,
     detect_language,
     extract_filename,
     format_timestamp,
@@ -25,6 +30,42 @@ from copilot_session_tools.utils import (
     truncate_preview,
     urldecode,
 )
+
+
+class TestBuildRootAgentMarkers:
+    """Tests for root custom-agent transition markers."""
+
+    def test_direct_agent_switch_does_not_emit_default_marker(self):
+        session = ChatSession(
+            session_id="root-agent-marker-test",
+            workspace_name="test-workspace",
+            workspace_path="/test",
+            messages=[
+                ChatMessage(role="user", content="first", timestamp="2026-01-01T00:00:02Z"),
+                ChatMessage(role="user", content="second", timestamp="2026-01-01T00:00:04Z"),
+            ],
+            root_agent_intervals=[
+                RootAgentInterval(
+                    agent_name="smart-merge",
+                    agent_display_name="Smart Merge",
+                    start_timestamp="2026-01-01T00:00:01Z",
+                    end_timestamp="2026-01-01T00:00:03Z",
+                ),
+                RootAgentInterval(
+                    agent_name="skill-audit",
+                    agent_display_name="Skill Audit",
+                    start_timestamp="2026-01-01T00:00:03Z",
+                ),
+            ],
+        )
+
+        markers = build_root_agent_markers(session)
+
+        assert markers == {
+            0: [{"kind": "enter", "label": "Entered Smart Merge", "timestamp": "2026-01-01T00:00:01Z"}],
+            1: [{"kind": "enter", "label": "Entered Skill Audit", "timestamp": "2026-01-01T00:00:03Z"}],
+        }
+
 
 # ---------------------------------------------------------------------------
 # format_timestamp
@@ -428,9 +469,9 @@ class TestSanitizeFilename:
 # ---------------------------------------------------------------------------
 
 
-def _session(**kwargs) -> ChatSession:
+def _session(**kwargs: Any) -> ChatSession:
     """Helper to build a ChatSession with sensible defaults."""
-    defaults = {
+    defaults: dict[str, Any] = {
         "session_id": "abcdef1234567890abcdef",
         "workspace_name": None,
         "workspace_path": None,
@@ -439,7 +480,7 @@ def _session(**kwargs) -> ChatSession:
         "custom_title": None,
     }
     defaults.update(kwargs)
-    return ChatSession(**defaults)  # ty: ignore[not-subscriptable]
+    return ChatSession(**defaults)
 
 
 class TestGenerateSessionFilename:

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from copilot_session_tools import ChatMessage, ChatSession, ContentBlock, Database
+from copilot_session_tools import ChatMessage, ChatSession, ContentBlock, Database, RootAgentInterval
 from copilot_session_tools.utils import (
     extract_filename as _extract_filename,
 )
@@ -263,6 +263,37 @@ class TestWebappRoutes:
         response = client.get("/session/webapp-test-session")
         assert response.status_code == 200
         assert b"What is Python?" in response.data
+
+    def test_session_shows_root_agent_transition_pills(self, temp_db):
+        """Root custom-agent intervals render as timeline transition pills."""
+        db = Database(temp_db)
+        session = ChatSession(
+            session_id="root-agent-web-session",
+            workspace_name="test-workspace",
+            workspace_path="/home/user/test",
+            messages=[
+                ChatMessage(role="user", content="Merge main", timestamp="2026-01-01T00:00:02Z"),
+                ChatMessage(role="assistant", content="Merged.", timestamp="2026-01-01T00:00:03Z"),
+                ChatMessage(role="user", content="Thanks", timestamp="2026-01-01T00:00:05Z"),
+            ],
+            root_agent_intervals=[
+                RootAgentInterval(
+                    agent_name="smart-merge",
+                    agent_display_name="smart-merge",
+                    start_timestamp="2026-01-01T00:00:01Z",
+                    end_timestamp="2026-01-01T00:00:04Z",
+                )
+            ],
+        )
+        db.add_session(session)
+
+        app = create_app(temp_db, title="Test Archive", storage_paths=[])
+        app.config["TESTING"] = True
+        response = app.test_client().get("/session/root-agent-web-session")
+
+        assert response.status_code == 200
+        assert b"Entered smart-merge" in response.data
+        assert b"Back to default" in response.data
 
     def test_session_not_found(self, client):
         """Test 404 for non-existent session."""

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.10.4"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Scanner | Parse CLI `subagent.selected` / `subagent.deselected` into root custom-agent intervals while keeping spawned task subagents separate. |
| Database | Add `cst_root_agent_intervals` plus usage/message/tool views for root-agent audit queries. |
| Rendering | Show left-aligned transcript transition pills for entering a root agent and returning to default mode. |
| Exports | Include root-agent transition pills in static HTML export. |
| Tests/types | Add scanner, database, web, marker, and snapshot coverage; clean Ty diagnostics. |
| Version | Bump package version to `0.11.0`. |

## Review and validation

- Tri-review completed with no high-severity findings.
- Medium findings addressed: guard timestamp-less root-agent selections, suppress false `Back to default` on direct agent switches, and include nested spawned-subagent activity in root-agent usage views.
- Local full gate passed: `823 passed, 13 skipped` plus Ruff lint, Ruff format check, and Ty type check.

## Breaking changes

None.