### PR TITLE
fix: handle freeform CLI tool arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.11.0"
+version = "0.11.1"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 from .content_types import (
     CONTENT_TYPES,

--- a/src/copilot_session_tools/scanner/cli.py
+++ b/src/copilot_session_tools/scanner/cli.py
@@ -20,6 +20,29 @@ from .models import (
 )
 
 
+def _as_tool_argument_dict(arguments: object) -> dict[str, object]:
+    """Return mapping-style tool arguments; freeform tools may store a string."""
+    return {str(key): value for key, value in arguments.items()} if isinstance(arguments, dict) else {}
+
+
+def _serialize_tool_arguments(arguments: object) -> str | None:
+    """Serialize tool arguments for storage without losing freeform string input."""
+    if not arguments:
+        return None
+    if isinstance(arguments, str):
+        return arguments
+    try:
+        return json.dumps(arguments)
+    except (TypeError, ValueError):
+        return str(arguments)
+
+
+def _get_tool_arg_str(arguments: dict[str, object], key: str, default: str = "") -> str:
+    """Get a string-valued tool argument."""
+    value = arguments.get(key)
+    return value if isinstance(value, str) else default
+
+
 def _parse_workspace_yaml(session_dir: Path) -> dict[str, str]:
     """Parse a workspace.yaml file from a CLI session directory.
 
@@ -132,8 +155,9 @@ class _CliSessionBuilder:
         self.current_assistant_command_runs = []
         self.current_assistant_timestamp = None
 
-    def build_tool_invocation(self, tool_call_id: str, tool_name: str, arguments: dict) -> tuple[ToolInvocation | None, CommandRun | None]:
+    def build_tool_invocation(self, tool_call_id: str, tool_name: str, arguments: object) -> tuple[ToolInvocation | None, CommandRun | None]:
         """Build a ToolInvocation or CommandRun from tool request data."""
+        argument_dict = _as_tool_argument_dict(arguments)
         # Get execution result if available
         execution = self.tool_executions.get(tool_call_id, {})
         complete_event = execution.get("complete")
@@ -156,19 +180,21 @@ class _CliSessionBuilder:
         mcp_tool_name = None
         if start_event:
             start_data = start_event.get("data", {})
-            start_args = start_data.get("arguments", {})
-            description = start_args.get("description")
-            mcp_server_name = start_data.get("mcpServerName")
-            mcp_tool_name = start_data.get("mcpToolName")
+            start_args = _as_tool_argument_dict(start_data.get("arguments", {}))
+            description = _get_tool_arg_str(start_args, "description") or None
+            server_name = start_data.get("mcpServerName")
+            tool_name_value = start_data.get("mcpToolName")
+            mcp_server_name = server_name if isinstance(server_name, str) else None
+            mcp_tool_name = tool_name_value if isinstance(tool_name_value, str) else None
         if not description:
-            description = arguments.get("description")
+            description = _get_tool_arg_str(argument_dict, "description") or None
 
         # Check if this is a shell/powershell command
         if tool_name in ("powershell", "bash", "shell", "run_command"):
-            command = arguments.get("command", "")
-            shell_mode = arguments.get("mode", "")
-            shell_id = arguments.get("shellId", "")
-            detach = arguments.get("detach", False)
+            command = _get_tool_arg_str(argument_dict, "command")
+            shell_mode = _get_tool_arg_str(argument_dict, "mode")
+            shell_id = _get_tool_arg_str(argument_dict, "shellId")
+            detach = argument_dict.get("detach", False)
             is_async = shell_mode in ("async", "background") or bool(detach)
             return None, CommandRun(
                 command=command,
@@ -182,17 +208,12 @@ class _CliSessionBuilder:
             )
         else:
             # Regular tool invocation
-            input_str = None
-            if arguments:
-                try:
-                    input_str = json.dumps(arguments)
-                except (TypeError, ValueError):
-                    input_str = str(arguments)
+            input_str = _serialize_tool_arguments(arguments)
 
             # Build invocation message for inline display
             invocation_message = _format_tool_display_message(
                 tool_name,
-                arguments,
+                argument_dict,
                 description,
                 mcp_server_name=mcp_server_name,
                 mcp_tool_name=mcp_tool_name,
@@ -207,11 +228,12 @@ class _CliSessionBuilder:
                 source_type="mcp" if mcp_server_name else None,
             ), None
 
-    def add_tool_inline(self, tool_call_id: str, tool_name: str, arguments: dict, *, intention_summary: str | None = None, tool_title: str | None = None) -> None:
+    def add_tool_inline(self, tool_call_id: str, tool_name: str, arguments: object, *, intention_summary: str | None = None, tool_title: str | None = None) -> None:
         """Add a tool invocation inline in the current assistant message."""
+        argument_dict = _as_tool_argument_dict(arguments)
         # Handle special meta-tools with pretty formatting
         if tool_name == "report_intent":
-            intent_text = arguments.get("intent", arguments.get("description", ""))
+            intent_text = _get_tool_arg_str(argument_dict, "intent") or _get_tool_arg_str(argument_dict, "description")
             if intent_text:
                 self.current_assistant_content_blocks.append(
                     ContentBlock(
@@ -222,7 +244,7 @@ class _CliSessionBuilder:
             return
 
         if tool_name == "skill":
-            skill_name = arguments.get("name", arguments.get("skill", ""))
+            skill_name = _get_tool_arg_str(argument_dict, "name") or _get_tool_arg_str(argument_dict, "skill")
             if skill_name:
                 self.current_assistant_content_blocks.append(
                     ContentBlock(
@@ -233,8 +255,9 @@ class _CliSessionBuilder:
             return
 
         if tool_name == "ask_user":
-            question = arguments.get("question") or arguments.get("message", "")
-            choices = arguments.get("choices", [])
+            question = _get_tool_arg_str(argument_dict, "question") or _get_tool_arg_str(argument_dict, "message")
+            choices_value = argument_dict.get("choices", [])
+            choices = choices_value if isinstance(choices_value, list) else []
             if question:
                 content = f"❓ {question}"
                 if choices:
@@ -278,7 +301,7 @@ class _CliSessionBuilder:
             "stop_powershell": "stop",
         }
         if tool_name in shell_interaction_tools:
-            shell_id = arguments.get("shellId", "")
+            shell_id = str(argument_dict.get("shellId", ""))
             action = shell_interaction_tools[tool_name]
             shell_title = self.shell_title_map.get(shell_id, shell_id) if shell_id else ""
             label = f"↩ {shell_title} — {action}" if shell_title else f"↩ shell — {action}"
@@ -293,7 +316,7 @@ class _CliSessionBuilder:
 
         # Resolve read_agent agent_id to display name
         if tool_name == "read_agent":
-            agent_id = arguments.get("agent_id", "")
+            agent_id = str(argument_dict.get("agent_id", ""))
             display = self.agent_display_names.get(agent_id, agent_id)
             resolved_msg = f"⏳ Checking agent {display}"
             self.current_assistant_content_blocks.append(ContentBlock(kind="toolInvocation", content=resolved_msg))
@@ -506,9 +529,9 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                         # Build display name from task tool arguments
                         start_info = tool_executions[tool_call_id].get("start")
                         if start_info:
-                            args = start_info.get("data", {}).get("arguments", {})
-                            agent_type = args.get("agent_type", "agent")
-                            desc = args.get("description", "")
+                            args = _as_tool_argument_dict(start_info.get("data", {}).get("arguments", {}))
+                            agent_type = _get_tool_arg_str(args, "agent_type", "agent")
+                            desc = _get_tool_arg_str(args, "description")
                             agent_display_names[bg_id] = f"{agent_type}: {desc}" if desc else agent_type
                     # Collect read_agent results for background agents
                     start_info = tool_executions[tool_call_id].get("start")
@@ -522,7 +545,8 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                         # Use the longer of content-after-Result vs detailedContent
                         best = result_from_content if len(result_from_content) > len(detailed) else detailed
                         if best:
-                            agent_id = start_info["data"].get("arguments", {}).get("agent_id", "")
+                            args = _as_tool_argument_dict(start_info["data"].get("arguments", {}))
+                            agent_id = str(args.get("agent_id", ""))
                             # Only keep the best (longest) result per agent
                             if len(best) > len(bg_agent_results.get(agent_id, "")):
                                 bg_agent_results[agent_id] = best
@@ -779,8 +803,8 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 display_name = event_data.get("agentDisplayName") or event_data.get("agentName", "unknown")
                 tool_call_id = event_data.get("toolCallId", "")
                 req = builder.pending_tool_requests.get(tool_call_id, {})
-                req_args = req.get("arguments", {})
-                description = req_args.get("description", "")
+                req_args = _as_tool_argument_dict(req.get("arguments", {}))
+                description = _get_tool_arg_str(req_args, "description")
                 failed = tool_call_id in builder.subagent_failures
                 completed = tool_call_id in builder.subagent_completions
                 # Title includes status indicator for template
@@ -871,7 +895,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                     content=content,
                     description=title,
                     child_message=child_msg,
-                    prompt=req_args.get("prompt", ""),
+                    prompt=_get_tool_arg_str(req_args, "prompt"),
                     is_background=is_bg,
                     agent_id=bg_id if is_bg else "",
                 )
@@ -885,8 +909,8 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 display_name = event_data.get("agentDisplayName") or event_data.get("agentName", "unknown")
                 tool_call_id = event_data.get("toolCallId", "")
                 req = builder.pending_tool_requests.get(tool_call_id, {})
-                req_args = req.get("arguments", {})
-                description = req_args.get("description", "")
+                req_args = _as_tool_argument_dict(req.get("arguments", {}))
+                description = _get_tool_arg_str(req_args, "description")
                 label = f"{display_name}: {description} — completed" if description else f"{display_name} — completed"
                 builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=label, description="subagent"))
 
@@ -894,8 +918,8 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 display_name = event_data.get("agentDisplayName") or event_data.get("agentName", "unknown")
                 tool_call_id = event_data.get("toolCallId", "")
                 req = builder.pending_tool_requests.get(tool_call_id, {})
-                req_args = req.get("arguments", {})
-                description = req_args.get("description", "")
+                req_args = _as_tool_argument_dict(req.get("arguments", {}))
+                description = _get_tool_arg_str(req_args, "description")
                 label = f"{display_name}: {description} — failed" if description else f"{display_name} — failed"
                 builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=label, description="subagent-error"))
 
@@ -927,6 +951,11 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 branch = event_data.get("branch") or ""
                 branch_info = f" ({branch})" if branch else ""
                 builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=f"Context changed: {cwd}{branch_info}", description="context-change"))
+
+            elif event_type == "session.remote_steerable_changed":
+                remote_steerable = event_data.get("remoteSteerable")
+                state = "enabled" if remote_steerable else "disabled"
+                builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=f"Remote steering {state}", description="remote-steering"))
 
             elif event_type == "session.plan_changed":
                 operation = event_data.get("operation") or "changed"
@@ -1021,9 +1050,23 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 "exit_plan_mode.completed",
                 # Internal state tracking
                 "pending_messages.modified",
+                # Ephemeral SDK/client dispatch events. Slash-command chat content
+                # persists through user.message/session.mode_changed instead.
+                "capabilities.changed",
+                "command.execute",
+                "commands.changed",
+                "mcp.oauth_completed",
+                "mcp.oauth_required",
+                "sampling.completed",
+                "sampling.requested",
                 "session.background_tasks_changed",
+                "session.custom_agents_updated",
+                "session.extensions_loaded",
                 "session.idle",
                 "session.import_legacy",
+                "session.mcp_server_status_changed",
+                "session.mcp_servers_loaded",
+                "session.skills_loaded",
                 "session.snapshot_rewind",
                 "session.tools_updated",
                 "session.usage_info",

--- a/src/copilot_session_tools/scanner/content.py
+++ b/src/copilot_session_tools/scanner/content.py
@@ -292,10 +292,13 @@ def _humanize_server_name(server_name: str) -> str:
     return " ".join(word.capitalize() for word in server_name.replace("-", " ").replace("_", " ").split())
 
 
-def _extract_best_param(arguments: dict) -> str:
+def _extract_best_param(arguments: object) -> str:
     """Extract the most descriptive parameter value from tool arguments."""
+    if not isinstance(arguments, dict):
+        return ""
+    argument_dict: dict[str, object] = {str(key): value for key, value in arguments.items()}
     for key in ("question", "query", "intent", "identifier", "description", "url", "path", "repoName", "libraryName"):
-        val = arguments.get(key)
+        val = argument_dict.get(key)
         if val and isinstance(val, str):
             return val[:100] + "..." if len(val) > 100 else val
     return ""
@@ -334,27 +337,28 @@ _TOOL_DISPLAY_FORMATS: dict[str, tuple[str, list[str]]] = {
 
 def _format_tool_display_message(
     tool_name: str,
-    arguments: dict,
+    arguments: object,
     description: str | None = None,
     mcp_server_name: str | None = None,
     mcp_tool_name: str | None = None,
 ) -> str:
     """Generate a display message for a tool invocation using data-driven formats."""
+    argument_dict: dict[str, object] = {str(key): value for key, value in arguments.items()} if isinstance(arguments, dict) else {}
     fmt = _TOOL_DISPLAY_FORMATS.get(tool_name)
     if fmt:
         template, arg_keys = fmt
         # Build substitution dict
         subs: dict[str, str] = {}
         for key in arg_keys:
-            val = arguments.get(key, "")
+            val = argument_dict.get(key, "")
             subs[key] = str(val) if val else ""
         # Fallback: if 'question' is empty but 'message' exists (ask_user tool)
         if not subs.get("question") and subs.get("message"):
             subs["question"] = subs["message"]
         # Auto-generate short_path from path arg (default to empty)
         subs.setdefault("short_path", "")
-        if "path" in arguments:
-            subs["short_path"] = _shorten_path(arguments.get("path", ""))
+        if "path" in argument_dict:
+            subs["short_path"] = _shorten_path(str(argument_dict.get("path", "")))
         # Auto-generate truncated versions
         for key in ("query", "url", "question", "message"):
             if key in subs:
@@ -367,8 +371,8 @@ def _format_tool_display_message(
 
     # Handle str_replace_editor specially (command-dependent)
     if tool_name == "str_replace_editor":
-        cmd = arguments.get("command", "view")
-        path = _shorten_path(arguments.get("path", ""))
+        cmd = argument_dict.get("command", "view")
+        path = _shorten_path(str(argument_dict.get("path", "")))
         if cmd == "create":
             return f"Created `{path}`"
         elif cmd == "str_replace":

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2740,12 +2740,24 @@ class TestCLIv105EventHandlers:
             "assistant.reasoning_delta",
             "assistant.streaming_delta",
             "assistant.intent",
+            "capabilities.changed",
+            "command.execute",
+            "commands.changed",
             "exit_plan_mode.requested",
             "exit_plan_mode.completed",
+            "mcp.oauth_completed",
+            "mcp.oauth_required",
             "pending_messages.modified",
+            "sampling.completed",
+            "sampling.requested",
             "session.background_tasks_changed",
+            "session.custom_agents_updated",
+            "session.extensions_loaded",
             "session.idle",
             "session.import_legacy",
+            "session.mcp_server_status_changed",
+            "session.mcp_servers_loaded",
+            "session.skills_loaded",
             "session.snapshot_rewind",
             "session.tools_updated",
             "session.usage_info",
@@ -2800,6 +2812,53 @@ class TestCLIv105EventHandlers:
         # Only the text block from assistant.message, no hook-related blocks
         status_blocks = [b for b in all_blocks if b.kind == "status"]
         assert len(status_blocks) == 0
+
+    def test_remote_steerable_changed_renders_status(self, tmp_path):
+        """session.remote_steerable_changed should render the remote steering state."""
+        session = self._parse(
+            tmp_path,
+            {"type": "user.message", "data": {"content": "Start remote work"}},
+            {"type": "assistant.message", "data": {"content": "Starting."}},
+            {"type": "session.remote_steerable_changed", "data": {"remoteSteerable": True}},
+        )
+        blocks = self._find_status_blocks(session, "remote-steering")
+        assert len(blocks) == 1
+        assert blocks[0].content == "Remote steering enabled"
+
+    def test_freeform_tool_string_arguments_parse(self, tmp_path):
+        """Freeform tools like apply_patch can store arguments as a raw string."""
+        patch = "*** Begin Patch\n*** Add File: example.txt\n+hello\n*** End Patch\n"
+        tool_call_id = "custom_call_string_args"
+
+        session = self._parse(
+            tmp_path,
+            {"type": "user.message", "data": {"content": "Add the file"}},
+            {"type": "assistant.message", "data": {"content": "Applying the patch."}},
+            {
+                "type": "tool.execution_start",
+                "data": {
+                    "toolCallId": tool_call_id,
+                    "toolName": "apply_patch",
+                    "arguments": patch,
+                },
+            },
+            {
+                "type": "tool.execution_complete",
+                "data": {
+                    "toolCallId": tool_call_id,
+                    "success": True,
+                    "result": {"content": "Modified 1 file(s): example.txt"},
+                },
+            },
+        )
+
+        assert session is not None
+        assistant = session.messages[1]
+        assert assistant.tool_invocations[0].name == "apply_patch"
+        assert assistant.tool_invocations[0].input == patch
+        assert assistant.tool_invocations[0].status == "success"
+        tool_blocks = [block for block in assistant.content_blocks if block.kind == "toolInvocation"]
+        assert tool_blocks[0].content == "apply_patch"
 
     # ---- T7: session.title_changed ----
 

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

| Area | Change |
| --- | --- |
| CLI scanner | Accept non-dict/freeform tool arguments, preserving raw string input for tools such as `apply_patch`. |
| Rendering helpers | Guard tool-display formatting against string arguments so parser/enrichment no longer crashes. |
| Tests | Add regression coverage for raw string `apply_patch` arguments and keep CLI event coverage current. |
| Release | Bump package version to `0.11.1`. |

## Validation

- `uv run pytest tests/ --ignore=tests/test_webapp_e2e.py -v`
- `uv run ty check`
- `uv run ruff check . --extend-exclude dummy --extend-exclude extract_chats.py`
- `uv run ruff format --check . --exclude dummy --exclude extract_chats.py`
- `uv run copilot-session-tools enrich 8f1d237f-3854-4f4a-93cb-95911a7a8996`
- `uv run copilot-session-tools search "pure categorization" --limit 3`

Notes: local whole-repo Ruff is blocked by unrelated local scratch `dummy\` and pre-existing tracked `extract_chats.py`; the pre-push hook passed after temporarily stashing only the unrelated scratch tree.

## Visual verification

Verified the previously failing real session renders in the web viewer and can be searched after enrichment.

## Breaking changes

None.