### PR TITLE
Make HTML session sections collapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+> Created/edited by GitHub Copilot with human review/feedback by avilevin.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -5,12 +7,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-06-02
+
+### Added
+
+- **Web Viewer / HTML Export**: Top-level User, Assistant, and included System messages now render as collapsible sections that are open by default.
+- **Web Viewer / HTML Export**: Auxiliary sections inside messages render as collapsible sections while preserving their existing default visibility.
+- **Content Types / Exporters**: `system-messages` is now an opt-in CONTENT flag that stays disabled by default in exports and search.
+
+### Changed
+
+- **Search**: Message searches exclude system-role messages by default unless an explicit role filter, such as `role=system`, is provided.
+
 ## [0.13.0] - 2026-05-29
 
 ### Added
 
 - **Web Viewer / HTML Export**: `role == "system"` messages now render as collapsible `<details>` blocks with a chevron, collapsed by default and expandable inline.
 - **Content Types / Exporters**: New `system-messages` content type for `--include/--exclude`. In markdown export, system messages are omitted unless included. In HTML export, system messages always render but are collapsed by default; including `system-messages` opens them by default.
+
+## [0.12.0] - 2026-05-26
+
+### Added
+
+- **Scanner**: Parse CLI `session.info` fork messages and render `Forked as` / `Forked from` status blocks with safe session links.
+- **Web Viewer / HTML Export**: Fork status badges can render sanitized Markdown links inline.
+- **Agent Workflow**: Replaced the old scanner-refresh skill with a project agent backed by configured `copilot-agent-runtime` or decompiled runtime paths.
+
+### Fixed
+
+- **Security**: Escaped fork links to prevent unsafe HTML injection in fork status rendering.
+
+## [0.11.1] - 2026-05-08
+
+### Fixed
+
+- **Scanner**: Accept non-dict/freeform tool arguments, preserving raw string input for tools such as `apply_patch`.
+- **Rendering Helpers**: Guard tool-display formatting against string arguments so parser/enrichment no longer crashes.
+
+## [0.11.0] - 2026-04-28
+
+### Added
+
+- **Scanner / Database**: Attribute root custom-agent sessions and persist their agent metadata through storage and retrieval.
+- **Web Viewer / HTML Export**: Surface root custom-agent attribution in rendered sessions.
+
+### Changed
+
+- **Scanner**: Improved custom-agent metadata extraction and utility normalization shared across CLI, HTML export, and web rendering.
+
+## [0.10.4] - 2026-04-14
+
+### Changed
+
+- **Transcript Cleanup**: Added structured output auto-dispatch across GPT chat completions, GPT Responses API text format, and Claude/Gemini tool-choice paths.
+- **Transcript Cleanup**: Updated the default cleanup model and LiteLLM minimum version for the structured output integration.
+
+### Fixed
+
+- **Transcript Cleanup**: Pass the system prompt through the correct model-specific parameter and raise a clear error on empty structured-output responses.
 
 ## [0.10.3] - 2026-04-05
 
@@ -40,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Web Viewer**: "Syntax highlighting" toggle in View Settings → Display section (persisted in localStorage)
 - **Web Viewer / HTML Export**: Unified diff output from tools highlighted with red/green coloring
 - **Markdown Export**: Tool inputs with JSON content now use language-tagged code fences (` ```json `) with prettified content
-- **Dependencies**: Added `pygments>=2.17.0` as a core dependency for server-side syntax highlightingorigin/main
+- **Dependencies**: Added `pygments>=2.17.0` as a core dependency for server-side syntax highlighting
 
 ## [0.10.1] - 2026-04-02
 
@@ -338,28 +393,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **CI/CD**: PyPI publishing infrastructure
-
-## [0.1.0] - 2025-02-13
-
-### Added
-
-- **Scanner**: Scan VS Code workspace storage (Stable and Insiders editions) to find Copilot chat sessions
-- **Scanner**: GitHub Copilot CLI chat history support (JSONL format from `~/.copilot/session-state`)
-- **Scanner**: Support for VS Code JSONL append-log format (VS Code >=1.109)
-- **Database**: SQLite storage with FTS5 full-text search indexing
-- **Database**: Two-layer design with raw compressed JSON as source of truth and derived tables
-- **Database**: Incremental scan support (only imports new/changed sessions)
-- **CLI**: `scan` command to import sessions from VS Code and CLI
-- **CLI**: `search` command with advanced query syntax (field filters, exact phrases, boolean logic)
-- **CLI**: `stats` command for database statistics
-- **CLI**: `export` command for JSON export
-- **CLI**: `export-markdown` command for Markdown export
-- **CLI**: `export-html` command for self-contained HTML export
-- **CLI**: `import-json` command for JSON import
-- **CLI**: `rebuild` command to recreate derived tables from raw JSON
-- **Web**: Flask-based web interface for browsing chat sessions
-- **Web**: Full-text search with highlighting
-- **Web**: Dark mode support via CSS `prefers-color-scheme`
-- **Web**: Syntax highlighting for code blocks
-- **Web**: Incremental refresh without restarting
-- **Tracking**: Tool invocations, file changes, and command runs from chat sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-> Created/edited by GitHub Copilot with human review/feedback by avilevin.
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -393,3 +391,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **CI/CD**: PyPI publishing infrastructure
+
+## [0.1.0] - 2025-02-13
+
+### Added
+
+- **Scanner**: Scan VS Code workspace storage (Stable and Insiders editions) to find Copilot chat sessions
+- **Scanner**: GitHub Copilot CLI chat history support (JSONL format from `~/.copilot/session-state`)
+- **Scanner**: Support for VS Code JSONL append-log format (VS Code >=1.109)
+- **Database**: SQLite storage with FTS5 full-text search indexing
+- **Database**: Two-layer design with raw compressed JSON as source of truth and derived tables
+- **Database**: Incremental scan support (only imports new/changed sessions)
+- **CLI**: `scan` command to import sessions from VS Code and CLI
+- **CLI**: `search` command with advanced query syntax (field filters, exact phrases, boolean logic)
+- **CLI**: `stats` command for database statistics
+- **CLI**: `export` command for JSON export
+- **CLI**: `export-markdown` command for Markdown export
+- **CLI**: `export-html` command for self-contained HTML export
+- **CLI**: `import-json` command for JSON import
+- **CLI**: `rebuild` command to recreate derived tables from raw JSON
+- **Web**: Flask-based web interface for browsing chat sessions
+- **Web**: Full-text search with highlighting
+- **Web**: Dark mode support via CSS `prefers-color-scheme`
+- **Web**: Syntax highlighting for code blocks
+- **Web**: Incremental refresh without restarting
+- **Tracking**: Tool invocations, file changes, and command runs from chat sessions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.13.0"
+version = "0.14.0"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 from .content_types import (
     CONTENT_TYPES,

--- a/src/copilot_session_tools/content_types.py
+++ b/src/copilot_session_tools/content_types.py
@@ -14,7 +14,7 @@ import typer
 
 CONTENT_TYPES: dict[str, str] = {
     "thinking": "Include thinking/reasoning blocks",
-    "system-messages": "Expand system-role messages by default",
+    "system-messages": "Include system-role messages",
     "diffs": "Include file change diffs",
     "tool-inputs": "Include tool input parameters",
     "agent-details": "Include full agent/subagent content",

--- a/src/copilot_session_tools/database.py
+++ b/src/copilot_session_tools/database.py
@@ -481,8 +481,8 @@ class Database:
             query: The search query (supports field prefixes and quoted phrases).
             limit: Maximum number of results to return (top).
             skip: Number of results to skip (for pagination).
-            role: Filter by message role ('user', 'assistant', or None for both).
-                  Can also be specified in query as 'role:user' or 'role:assistant'.
+            role: Filter by message role ('user', 'assistant', 'system', or None for non-system messages).
+                  Can also be specified in query as 'role:user', 'role:assistant', or 'role:system'.
             search_content_set: Set of content type tokens controlling which
                 data sources are searched.  See ``content_types.SEARCH_CONTENT_TYPES``.
             include_messages: Deprecated — use *search_content_set*.

--- a/src/copilot_session_tools/db_search.py
+++ b/src/copilot_session_tools/db_search.py
@@ -410,6 +410,8 @@ def _search_messages(
         if effective_role:
             message_query += " AND m.role = ?"
             params.append(effective_role)
+        else:
+            message_query += " AND m.role != 'system'"
 
         message_query = _append_session_filters(message_query, params, **filter_kwargs)
 
@@ -444,6 +446,8 @@ def _search_messages(
         if effective_role:
             message_query += " AND m.role = ?"
             params.append(effective_role)
+        else:
+            message_query += " AND m.role != 'system'"
 
         message_query = _append_session_filters(message_query, params, **filter_kwargs)
 

--- a/src/copilot_session_tools/html_exporter.py
+++ b/src/copilot_session_tools/html_exporter.py
@@ -105,9 +105,6 @@ def session_to_html(session: ChatSession, content_set: set[str] | None = None) -
         static_hide_classes_list.append("hide-commands")
     if "file-changes" not in content_set:
         static_hide_classes_list.append("hide-file-changes")
-    if include_system_messages:
-        static_hide_classes_list.append("expand-system-messages")
-
     first_user_prompt, message_metadata = _preprocess_messages(session)
     env = _get_jinja_env()
     template = env.get_template("session.html")

--- a/src/copilot_session_tools/web/templates/session.html
+++ b/src/copilot_session_tools/web/templates/session.html
@@ -463,6 +463,21 @@ header h1 {
     margin-bottom: 0;
 }
 
+.message-details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.message-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.message-details > summary .collapsible-icon {
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    line-height: 1;
+}
+
 .message-anchor {
     color: var(--text-secondary);
     text-decoration: none;
@@ -1020,14 +1035,6 @@ header h1 {
 .system-message-details > summary .collapsible-icon {
     display: inline-block;
     color: var(--text-secondary);
-}
-
-.system-message-details[open] > summary .collapsible-icon {
-    transform: rotate(90deg);
-}
-
-.expand-system-messages .system-message-details {
-    opacity: 1;
 }
 
 /* Agent back-link */
@@ -2056,6 +2063,7 @@ footer a {
 
 /* Toggle hide rules — driven by Alpine settings panel */
 .hide-thinking .thinking-block { display: none !important; }
+.hide-system-messages .message.system { display: none !important; }
 .hide-diffs .file-change .diff { display: none !important; }
 .hide-tool-inputs .tool-section-input { display: none !important; }
 /* Tools OFF: hide collapsible wrappers + section header + summaries, show inline fallbacks */
@@ -2071,6 +2079,7 @@ footer a {
 
 /* Prevent hidden elements from being chosen as scroll anchors */
 .thinking-block,
+.message.system,
 .tool-invocation-wrapper,
 .tool-section-input,
 .subagent-content,
@@ -2253,6 +2262,7 @@ input:checked + .toggle-switch::after {
         diffs: true,
         toolInputs: true,
         agentDetails: true,
+        systemMessages: false,
         tools: true,
         commands: true,
         fileChanges: true,
@@ -2289,6 +2299,7 @@ input:checked + .toggle-switch::after {
           if (!this.diffs) classes.push('hide-diffs');
           if (!this.toolInputs) classes.push('hide-tool-inputs');
           if (!this.agentDetails) classes.push('hide-agent-details');
+          if (!this.systemMessages) classes.push('hide-system-messages');
           if (!this.tools) classes.push('hide-tools');
           if (!this.commands) classes.push('hide-commands');
           if (!this.fileChanges) classes.push('hide-file-changes');
@@ -2322,6 +2333,10 @@ input:checked + .toggle-switch::after {
             const anchor = this.getAnchorState();
             this.$nextTick(() => { this.restoreScroll(anchor); this.saveSettings(); });
           });
+          this.$watch('systemMessages', () => {
+            const anchor = this.getAnchorState();
+            this.$nextTick(() => { this.restoreScroll(anchor); this.saveSettings(); });
+          });
           this.$watch('tools', () => {
             const anchor = this.getAnchorState();
             this.$nextTick(() => { this.restoreScroll(anchor); this.saveSettings(); });
@@ -2348,7 +2363,7 @@ input:checked + .toggle-switch::after {
           }
 
           // Toggle collapsible icon on details open/close
-          document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block').forEach(details => {
+          document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block, details.task-complete-block, details.subagent-block, details.subagent-prompt, details.thinking-block, details.system-message-details, details.message-details').forEach(details => {
             details.addEventListener('toggle', function() {
               const icon = this.querySelector(':scope > summary > .collapsible-icon');
               if (icon) {
@@ -2398,6 +2413,7 @@ input:checked + .toggle-switch::after {
             // Open clicked indicator's popover
             const indicator = e.target.closest('.cleanup-indicator');
             if (indicator) {
+              e.preventDefault();
               const popover = indicator.parentElement.querySelector('.cleanup-popover');
               if (popover) popover.classList.toggle('open');
             }
@@ -2407,6 +2423,7 @@ input:checked + .toggle-switch::after {
           document.addEventListener('click', async function(e) {
             const btn = e.target.closest('.popover-cleanup-btn');
             if (!btn) return;
+            e.preventDefault();
             const sessionId = btn.dataset.sessionId;
             const messageIndex = parseInt(btn.dataset.messageIndex);
             const msgEl = document.getElementById('msg-' + (messageIndex + 1));
@@ -2472,6 +2489,7 @@ input:checked + .toggle-switch::after {
           document.addEventListener('click', function(e) {
             const btn = e.target.closest('.popover-toggle-btn');
             if (!btn) return;
+            e.preventDefault();
             const msgIndex = btn.dataset.messageIndex;
             const msgEl = document.getElementById('msg-' + (parseInt(msgIndex) + 1));
             if (!msgEl) return;
@@ -2497,6 +2515,7 @@ input:checked + .toggle-switch::after {
           document.addEventListener('click', async function(e) {
             const btn = e.target.closest('.popover-revert-btn');
             if (!btn) return;
+            e.preventDefault();
             const sessionId = btn.dataset.sessionId;
             const messageIndex = parseInt(btn.dataset.messageIndex);
             const msgEl = document.getElementById('msg-' + (messageIndex + 1));
@@ -2541,7 +2560,7 @@ input:checked + .toggle-switch::after {
           try {
             localStorage.setItem('cst-settings', JSON.stringify({
               thinking: this.thinking, diffs: this.diffs, toolInputs: this.toolInputs,
-              agentDetails: this.agentDetails, tools: this.tools, commands: this.commands,
+              agentDetails: this.agentDetails, systemMessages: this.systemMessages, tools: this.tools, commands: this.commands,
               fileChanges: this.fileChanges, syntaxHighlight: this.syntaxHighlight
             }));
           } catch(e) {}
@@ -2550,7 +2569,7 @@ input:checked + .toggle-switch::after {
         buildContentSet() {
           const set = [];
           if (this.thinking) set.push('thinking');
-          set.push('system-messages');
+          if (this.systemMessages) set.push('system-messages');
           if (this.diffs) set.push('diffs');
           if (this.toolInputs) set.push('tool-inputs');
           if (this.agentDetails) set.push('agent-details');
@@ -2789,6 +2808,11 @@ input:checked + .toggle-switch::after {
                     <span class="toggle-switch"></span>
                     <span>Agent details</span>
                   </label>
+                  <label class="settings-toggle">
+                   <input type="checkbox" x-model="systemMessages">
+                   <span class="toggle-switch"></span>
+                   <span>System messages</span>
+                  </label>
                 </div>
 
                 <div class="settings-group">
@@ -2869,9 +2893,9 @@ input:checked + .toggle-switch::after {
                             <span class="intent-badge">{{ block.content }}</span>
                             {% elif block.kind == 'skill' %}
                             {% if block.description %}
-                            <details class="skill-block">
+                            <details class="skill-block" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="skill-badge-label">⚡ skill: <code>{{ block.content }}</code></span>
                                 </summary>
                                 <div class="skill-content">{{ block.description }}</div>
@@ -2885,9 +2909,9 @@ input:checked + .toggle-switch::after {
                             {% elif block.description == 'subagent-error' %}
                             {# Hidden: standalone subagent error pills are redundant with agent block headers and read_agent backlinks #}
                             {% elif block.description == 'task-complete' %}
-                            <details class="task-complete-block">
+                            <details class="task-complete-block" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="task-complete-label">✅ Task complete</span>
                                 </summary>
                                 <div class="task-complete-content">
@@ -2900,9 +2924,9 @@ input:checked + .toggle-switch::after {
                             <span class="status-badge {{ block.description or '' }}">{{ block.content }}</span>
                             {% endif %}
                             {% elif block.kind in ('subagent', 'subagent_failed', 'subagent_incomplete') %}
-                            <details class="subagent-block{% if block.kind == 'subagent_failed' %} subagent-failed{% endif %}{% if block.is_background %} subagent-background{% endif %}"{% if block.agent_id %} id="agent-{{ block.agent_id }}"{% endif %}>
+                            <details class="subagent-block{% if block.kind == 'subagent_failed' %} subagent-failed{% endif %}{% if block.is_background %} subagent-background{% endif %}"{% if block.agent_id %} id="agent-{{ block.agent_id }}"{% endif %} open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="subagent-label">{{ block.description or 'Agent' }}</span>
                                     {% if block.is_background %}
                                     <span class="subagent-background-badge">↗ background</span>
@@ -2918,7 +2942,7 @@ input:checked + .toggle-switch::after {
                                 <div class="subagent-content">
                                     {% if block.prompt %}
                                     <details class="subagent-prompt" open>
-                                        <summary class="subagent-prompt-label">Prompt</summary>
+                                        <summary class="subagent-prompt-label"><span class="collapsible-icon" aria-hidden="true">▼</span> Prompt</summary>
                                         <div class="subagent-prompt-content">
                                             {{ block.prompt | markdown | safe }}
                                         </div>
@@ -2951,9 +2975,9 @@ input:checked + .toggle-switch::after {
                                 </div>
                             </details>
                             {% elif block.kind == 'thinking' and (include_thinking is not defined or include_thinking) %}
-                            <details class="thinking-block">
+                            <details class="thinking-block" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="thinking-label">Thinking</span>
                                     {% if block.description %}
                                     <span class="thinking-description">— {{ block.description }}</span>
@@ -2973,9 +2997,9 @@ input:checked + .toggle-switch::after {
                             {% if matched_cmd %}
                             {# CLI command run - show as collapsible command block with Input/Output like VSCode logs #}
                             <div class="content-block content-block-toolInvocation tool-invocation-inline">
-                                <details class="tool-invocation-wrapper{% if matched_cmd.is_async %} command-async{% endif %}"{% if matched_cmd.shell_id %} id="shell-{{ matched_cmd.shell_id }}"{% endif %}>
+                                <details class="tool-invocation-wrapper{% if matched_cmd.is_async %} command-async{% endif %}"{% if matched_cmd.shell_id %} id="shell-{{ matched_cmd.shell_id }}"{% endif %} open>
                                     <summary>
-                                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                         <span class="tool-invocation-message">
                                             {% if matched_cmd.title %}
                                                 {{ matched_cmd.title }}
@@ -3124,9 +3148,9 @@ input:checked + .toggle-switch::after {
                             {% else %}
                             {% if show_collapsible %}
                             <div class="content-block content-block-toolInvocation tool-invocation-inline">
-                                <details class="tool-invocation-wrapper">
+                                <details class="tool-invocation-wrapper" open>
                                     <summary>
-                                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
                                         <span class="tool-invocation-message">{{ pretty_header | markdown | safe }}</span>
                                         {% if matched_tool.status %}
                                         <span class="status-badge {{ matched_tool.status }}">{{ matched_tool.status }}</span>
@@ -3211,9 +3235,9 @@ input:checked + .toggle-switch::after {
                     </summary>
                     <div class="collapsible-content">
                         {% for tool in unmatched_tools %}
-                        <details class="tool-invocation-wrapper">
+                        <details class="tool-invocation-wrapper" open>
                             <summary>
-                                <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                <span class="collapsible-icon" aria-hidden="true">▼</span>
                                 {% if tool.invocation_message %}
                                 <span class="tool-invocation-message">{{ tool.invocation_message | markdown | safe }}</span>
                                 {% else %}
@@ -3267,9 +3291,9 @@ input:checked + .toggle-switch::after {
 
                 {% if file_changes %}
                 <p class="tool-summary tool-summary-files"><em>Changed {{ file_changes | length }} file{{ 's' if file_changes | length > 1 else '' }}: {{ file_changes | map(attribute='path') | list | join(', ') | truncate(100) }}</em></p>
-                <details class="collapsible file-changes">
+                <details class="collapsible file-changes" open>
                     <summary aria-label="Toggle file changes section">
-                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                        <span class="collapsible-icon" aria-hidden="true">▼</span>
                         File Changes ({{ file_changes | length }})
                         <span class="preview-text">{{ file_changes | map(attribute='path') | map('extract_filename') | join(', ') | truncate(80) }}</span>
                     </summary>
@@ -3336,9 +3360,9 @@ input:checked + .toggle-switch::after {
                                 {% endif %}
                             </div>
                             {% if cmd.output %}
-                            <details class="terminal-output-toggle">
+                            <details class="terminal-output-toggle" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     Show output
                                 </summary>
                                 <div class="terminal-output-content">{{ cmd.output | strip_ansi }}</div>
@@ -3372,10 +3396,11 @@ input:checked + .toggle-switch::after {
                 </div>
             </div>
             {% elif message.role == 'system' %}
+            {% if not static or include_system_messages %}
             <div class="message system" id="msg-{{ loop.index }}">
-                <details class="system-message-details"{% if static and include_system_messages %} open{% endif %}>
+                <details class="message-details system-message-details" open>
                     <summary class="message-header">
-                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                        <span class="collapsible-icon" aria-hidden="true">▼</span>
                         <div class="message-role">{{ message.role }}</div>
                         {% if message.timestamp %}
                         <span class="message-timestamp">{{ message.timestamp | format_timestamp }}</span>
@@ -3394,16 +3419,19 @@ input:checked + .toggle-switch::after {
                     </div>
                 </details>
             </div>
+            {% endif %}
             {% else %}
             <div class="message {{ message.role }}" id="msg-{{ loop.index }}">
-                <div class="message-header">
+                <details class="message-details" open>
+                <summary class="message-header">
+                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                     <div class="message-role">{{ message.role }}</div>
                     {% if message.timestamp %}
                     <span class="message-timestamp">{{ message.timestamp | format_timestamp }}</span>
                     {% endif %}
-                    <a href="#msg-{{ loop.index }}" class="message-anchor" title="Link to this message">#{{ loop.index }}</a>
+                    <a href="#msg-{{ loop.index }}" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#{{ loop.index }}</a>
                     {% if not static %}
-                    <button type="button" class="message-copy-btn" data-message-index="{{ loop.index }}" data-session-id="{{ session.session_id }}" title="Copy this message as markdown" aria-label="Copy message as markdown">
+                    <button type="button" class="message-copy-btn" data-message-index="{{ loop.index }}" data-session-id="{{ session.session_id }}" title="Copy this message as markdown" aria-label="Copy message as markdown" onclick="event.stopPropagation()">
                         <i class="fa-regular fa-copy"></i>
                     </button>
                     {% endif %}
@@ -3428,7 +3456,7 @@ input:checked + .toggle-switch::after {
                       </div>
                     </span>
                     {% endif %}
-                </div>
+                </summary>
                 <div class="message-content">
                     {% if message.original_content is not none %}
                     <div class="message-original-content" data-msg-index="{{ loop.index0 }}">
@@ -3439,6 +3467,7 @@ input:checked + .toggle-switch::after {
                     {{ render_content_blocks(message.content_blocks, message.tool_invocations, message.file_changes, message.command_runs, msg_meta, message.content) }}
                     </div>
                 </div>
+                </details>
             </div>
             {% endif %}
             {% endfor %}
@@ -3467,21 +3496,31 @@ input:checked + .toggle-switch::after {
                 {% if turn.user_message %}
                 {% set ns2.msg_num = ns2.msg_num + 1 %}
                 <div class="message user basic-turn" id="msg-{{ ns2.msg_num }}">
-                    <div class="message-header">
+                    <details class="message-details" open>
+                    <summary class="message-header">
+                        <span class="collapsible-icon" aria-hidden="true">▼</span>
                         <div class="message-role">user</div>
-                        <a href="#msg-{{ ns2.msg_num }}" class="message-anchor" title="Link to this message">#{{ ns2.msg_num }}</a>
-                    </div>
+                        <a href="#msg-{{ ns2.msg_num }}" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#{{ ns2.msg_num }}</a>
+                    </summary>
+                    <div class="message-content">
                     {{ turn.user_message | markdown | safe }}
+                    </div>
+                    </details>
                 </div>
                 {% endif %}
                 {% if turn.assistant_response %}
                 {% set ns2.msg_num = ns2.msg_num + 1 %}
                 <div class="message assistant basic-turn" id="msg-{{ ns2.msg_num }}">
-                    <div class="message-header">
+                    <details class="message-details" open>
+                    <summary class="message-header">
+                        <span class="collapsible-icon" aria-hidden="true">▼</span>
                         <div class="message-role">assistant</div>
-                        <a href="#msg-{{ ns2.msg_num }}" class="message-anchor" title="Link to this message">#{{ ns2.msg_num }}</a>
-                    </div>
+                        <a href="#msg-{{ ns2.msg_num }}" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#{{ ns2.msg_num }}</a>
+                    </summary>
+                    <div class="message-content">
                     {{ turn.assistant_response | markdown | safe }}
+                    </div>
+                    </details>
                 </div>
                 {% endif %}
             {% endfor %}
@@ -3504,21 +3543,31 @@ input:checked + .toggle-switch::after {
                     {% if turn.user_message %}
                     {% set ns.msg_num = ns.msg_num + 1 %}
                     <div class="message user basic-turn" id="msg-{{ ns.msg_num }}">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-{{ ns.msg_num }}" class="message-anchor" title="Link to this message">#{{ ns.msg_num }}</a>
-                        </div>
+                            <a href="#msg-{{ ns.msg_num }}" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#{{ ns.msg_num }}</a>
+                        </summary>
+                        <div class="message-content">
                         {{ turn.user_message | markdown | safe }}
+                        </div>
+                        </details>
                     </div>
                     {% endif %}
                     {% if turn.assistant_response %}
                     {% set ns.msg_num = ns.msg_num + 1 %}
                     <div class="message assistant basic-turn" id="msg-{{ ns.msg_num }}">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-{{ ns.msg_num }}" class="message-anchor" title="Link to this message">#{{ ns.msg_num }}</a>
-                        </div>
+                            <a href="#msg-{{ ns.msg_num }}" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#{{ ns.msg_num }}</a>
+                        </summary>
+                        <div class="message-content">
                         {{ turn.assistant_response | markdown | safe }}
+                        </div>
+                        </details>
                     </div>
                     {% endif %}
                 {% endfor %}
@@ -3547,7 +3596,7 @@ input:checked + .toggle-switch::after {
                 }
             }
 
-            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block').forEach(details => {
+            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block, details.task-complete-block, details.subagent-block, details.subagent-prompt, details.thinking-block, details.system-message-details, details.message-details').forEach(details => {
                 details.addEventListener('toggle', function() {
                     const icon = this.querySelector(':scope > summary > .collapsible-icon');
                     if (icon) {

--- a/tests/snapshots/baselines/cli-unenriched.html
+++ b/tests/snapshots/baselines/cli-unenriched.html
@@ -450,6 +450,21 @@ header h1 {
     margin-bottom: 0;
 }
 
+.message-details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.message-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.message-details > summary .collapsible-icon {
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    line-height: 1;
+}
+
 .message-anchor {
     color: var(--text-secondary);
     text-decoration: none;
@@ -955,6 +970,24 @@ header h1 {
     border-radius: 4px;
     background: var(--bg-tertiary);
     display: inline-block;
+}
+
+.system-message-details {
+    opacity: 0.85;
+}
+
+.system-message-details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.system-message-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.system-message-details > summary .collapsible-icon {
+    display: inline-block;
+    color: var(--text-secondary);
 }
 
 /* Agent back-link */
@@ -1983,6 +2016,7 @@ footer a {
 
 /* Toggle hide rules — driven by Alpine settings panel */
 .hide-thinking .thinking-block { display: none !important; }
+.hide-system-messages .message.system { display: none !important; }
 .hide-diffs .file-change .diff { display: none !important; }
 .hide-tool-inputs .tool-section-input { display: none !important; }
 /* Tools OFF: hide collapsible wrappers + section header + summaries, show inline fallbacks */
@@ -1998,6 +2032,7 @@ footer a {
 
 /* Prevent hidden elements from being chosen as scroll anchors */
 .thinking-block,
+.message.system,
 .tool-invocation-wrapper,
 .tool-section-input,
 .subagent-content,
@@ -2188,10 +2223,13 @@ input:checked + .toggle-switch::after {
                     
                     
                     <div class="message user basic-turn" id="msg-1">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-1" class="message-anchor" title="Link to this message">#1</a>
-                        </div>
+                            <a href="#msg-1" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#1</a>
+                        </summary>
+                        <div class="message-content">
                         <p>Available Result Categories:</p>
 <pre><code class="language-json">[
   {
@@ -2230,36 +2268,51 @@ input:checked + .toggle-switch::after {
   &ldquo;confidence&rdquo;: &lt;0.0 to 1.0&gt;,<br />
   &ldquo;summary&rdquo;: &ldquo;<short summary of what occurred in the session being analyzed>&ldquo;<br />
 }</p>
+                        </div>
+                        </details>
                     </div>
                     
                     
                     
                     <div class="message assistant basic-turn" id="msg-2">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-2" class="message-anchor" title="Link to this message">#2</a>
-                        </div>
+                            <a href="#msg-2" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#2</a>
+                        </summary>
+                        <div class="message-content">
                         <p>The result file already exists with the correct classification. The session was indeed <strong>succeeded</strong> - the task was completed successfully.</p>
+                        </div>
+                        </details>
                     </div>
                     
                 
                     
                     
                     <div class="message user basic-turn" id="msg-3">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-3" class="message-anchor" title="Link to this message">#3</a>
-                        </div>
+                            <a href="#msg-3" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#3</a>
+                        </summary>
+                        <div class="message-content">
                         <p>You are analyzing the results of an agent execution. Based on the session file content below, classify the execution result into one of the available categories. Ensure your response is valid JSON and is NOT surrounded by markdown code blocks.</p>
+                        </div>
+                        </details>
                     </div>
                     
                     
                     
                     <div class="message assistant basic-turn" id="msg-4">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-4" class="message-anchor" title="Link to this message">#4</a>
-                        </div>
+                            <a href="#msg-4" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#4</a>
+                        </summary>
+                        <div class="message-content">
                         <p>{<br />
   &ldquo;name&rdquo;: &ldquo;succeeded&rdquo;,<br />
   &ldquo;code&rdquo;: 0,<br />
@@ -2270,30 +2323,40 @@ input:checked + .toggle-switch::after {
   &ldquo;confidence&rdquo;: 1.0,<br />
   &ldquo;summary&rdquo;: &ldquo;User asked a simple arithmetic question (1 + 1). Assistant correctly answered 2 and marked the task complete.&rdquo;<br />
 }</p>
+                        </div>
+                        </details>
                     </div>
                     
                 
                     
                     
                     <div class="message user basic-turn" id="msg-5">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-5" class="message-anchor" title="Link to this message">#5</a>
-                        </div>
+                            <a href="#msg-5" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#5</a>
+                        </summary>
+                        <div class="message-content">
                         <p><current_datetime>2026-02-09T07:57:46.281Z</current_datetime></p>
 <p>You are analyzing the results of an agent execution. Based on the session file content below, classify the execution result into one of the available categories. Ensure your response is valid JSON and is NOT surrounded by markdown code blocks.</p>
 <p><reminder><br />
 <sql_tables>No tables currently exist. Default tables (todos, todo_deps) will be created automatically when you first use the SQL tool.</sql_tables><br />
 </reminder></p>
+                        </div>
+                        </details>
                     </div>
                     
                     
                     
                     <div class="message assistant basic-turn" id="msg-6">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-6" class="message-anchor" title="Link to this message">#6</a>
-                        </div>
+                            <a href="#msg-6" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#6</a>
+                        </summary>
+                        <div class="message-content">
                         <p>{<br />
   &ldquo;name&rdquo;: &ldquo;succeeded&rdquo;,<br />
   &ldquo;code&rdquo;: 0,<br />
@@ -2304,37 +2367,52 @@ input:checked + .toggle-switch::after {
   &ldquo;confidence&rdquo;: 1.0,<br />
   &ldquo;summary&rdquo;: &ldquo;User asked a simple arithmetic question (1 + 1). Assistant correctly answered 2 and marked the task complete.&rdquo;<br />
 }</p>
+                        </div>
+                        </details>
                     </div>
                     
                 
                     
                     
                     <div class="message user basic-turn" id="msg-7">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-7" class="message-anchor" title="Link to this message">#7</a>
-                        </div>
+                            <a href="#msg-7" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#7</a>
+                        </summary>
+                        <div class="message-content">
                         <p>Intent logged</p>
+                        </div>
+                        </details>
                     </div>
                     
                     
                     
                     <div class="message assistant basic-turn" id="msg-8">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-8" class="message-anchor" title="Link to this message">#8</a>
-                        </div>
+                            <a href="#msg-8" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#8</a>
+                        </summary>
+                        <div class="message-content">
                         <p>The result.json file already exists with the correct classification. The session was classified as <strong>succeeded</strong> - the agent correctly answered &ldquo;1 + 1 = 2&rdquo; and called task_complete successfully.</p>
+                        </div>
+                        </details>
                     </div>
                     
                 
                     
                     
                     <div class="message user basic-turn" id="msg-9">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-9" class="message-anchor" title="Link to this message">#9</a>
-                        </div>
+                            <a href="#msg-9" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#9</a>
+                        </summary>
+                        <div class="message-content">
                         <ol>
 <li>{&ldquo;data&rdquo;:{&ldquo;copilotVersion&rdquo;:&rdquo;0.0.406&rdquo;,&rdquo;producer&rdquo;:&rdquo;agency&rdquo;,&rdquo;sessionId&rdquo;:&rdquo;4541686a-6b49-4c34-82b3-525c3b1c8106&rdquo;,&rdquo;startTime&rdquo;:&rdquo;2026-02-09T07:55:27.758Z&rdquo;,&rdquo;version&rdquo;:1},&rdquo;id&rdquo;:&rdquo;21e75518-b048-4be8-bc4a-2d844ceb8089&rdquo;,&rdquo;parentId&rdquo;:null,&rdquo;timestamp&rdquo;:&rdquo;2026-02-09T07:55:27.758Z&rdquo;,&rdquo;type&rdquo;:&rdquo;session.start&rdquo;}</li>
 <li>{&ldquo;type&rdquo;:&rdquo;session.resume&rdquo;,&rdquo;data&rdquo;:{&ldquo;resumeTime&rdquo;:&rdquo;2026-02-09T07:55:30.001Z&rdquo;,&rdquo;eventCount&rdquo;:1,&rdquo;context&rdquo;:{&ldquo;cwd&rdquo;:&rdquo;C:\_SRC\ZTS&rdquo;,&rdquo;gitRoot&rdquo;:&rdquo;C:\_SRC\ZTS&rdquo;,&rdquo;branch&rdquo;:&rdquo;main&rdquo;}},&rdquo;id&rdquo;:&rdquo;64e2b868-4dc6-4abf-8c50-730a9158c9c3&rdquo;,&rdquo;timestamp&rdquo;:&rdquo;2026-02-09T07:55:30.001Z&rdquo;,&rdquo;parentId&rdquo;:&rdquo;21e75518-b048-4be8-bc4a-2d844ceb8089&rdquo;}</li>
@@ -2350,15 +2428,20 @@ input:checked + .toggle-switch::after {
 <li>{&ldquo;type&rdquo;:&rdquo;assistant.turn_end&rdquo;,&rdquo;data&rdquo;:{&ldquo;turnId&rdquo;:&rdquo;1&rdquo;},&rdquo;id&rdquo;:&rdquo;9ca164cb-2d94-48b8-9c4f-2c52d7149df2&rdquo;,&rdquo;timestamp&rdquo;:&rdquo;2026-02-09T07:56:39.474Z&rdquo;,&rdquo;parentId&rdquo;:&rdquo;030c8f7b-b73d-4605-a389-0744cb619a76&rdquo;}<br />
 13.</li>
 </ol>
+                        </div>
+                        </details>
                     </div>
                     
                     
                     
                     <div class="message assistant basic-turn" id="msg-10">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-10" class="message-anchor" title="Link to this message">#10</a>
-                        </div>
+                            <a href="#msg-10" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#10</a>
+                        </summary>
+                        <div class="message-content">
                         <p>{<br />
   &ldquo;name&rdquo;: &ldquo;succeeded&rdquo;,<br />
   &ldquo;code&rdquo;: 0,<br />
@@ -2369,27 +2452,39 @@ input:checked + .toggle-switch::after {
   &ldquo;confidence&rdquo;: 1.0,<br />
   &ldquo;summary&rdquo;: &ldquo;User asked a simple arithmetic question (1 + 1). Assistant correctly answered 2 and marked the task complete.&rdquo;<br />
 }</p>
+                        </div>
+                        </details>
                     </div>
                     
                 
                     
                     
                     <div class="message user basic-turn" id="msg-11">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">user</div>
-                            <a href="#msg-11" class="message-anchor" title="Link to this message">#11</a>
-                        </div>
+                            <a href="#msg-11" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#11</a>
+                        </summary>
+                        <div class="message-content">
                         <p>The session completed successfully - the agent answered &ldquo;1 + 1 = 2&rdquo; and called <code>task_complete</code>. Let me write the classification.</p>
+                        </div>
+                        </details>
                     </div>
                     
                     
                     
                     <div class="message assistant basic-turn" id="msg-12">
-                        <div class="message-header">
+                        <details class="message-details" open>
+                        <summary class="message-header">
+                            <span class="collapsible-icon" aria-hidden="true">▼</span>
                             <div class="message-role">assistant</div>
-                            <a href="#msg-12" class="message-anchor" title="Link to this message">#12</a>
-                        </div>
+                            <a href="#msg-12" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#12</a>
+                        </summary>
+                        <div class="message-content">
                         <p>Classification written successfully. The session was classified as <strong>succeeded</strong> (exit code 0).</p>
+                        </div>
+                        </details>
                     </div>
                     
                 
@@ -2416,7 +2511,7 @@ input:checked + .toggle-switch::after {
                 }
             }
 
-            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block').forEach(details => {
+            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block, details.task-complete-block, details.subagent-block, details.subagent-prompt, details.thinking-block, details.system-message-details, details.message-details').forEach(details => {
                 details.addEventListener('toggle', function() {
                     const icon = this.querySelector(':scope > summary > .collapsible-icon');
                     if (icon) {

--- a/tests/snapshots/baselines/cli-with-agents.html
+++ b/tests/snapshots/baselines/cli-with-agents.html
@@ -438,6 +438,21 @@ header h1 {
     margin-bottom: 0;
 }
 
+.message-details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.message-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.message-details > summary .collapsible-icon {
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    line-height: 1;
+}
+
 .message-anchor {
     color: var(--text-secondary);
     text-decoration: none;
@@ -961,14 +976,6 @@ header h1 {
 .system-message-details > summary .collapsible-icon {
     display: inline-block;
     color: var(--text-secondary);
-}
-
-.system-message-details[open] > summary .collapsible-icon {
-    transform: rotate(90deg);
-}
-
-.expand-system-messages .system-message-details {
-    opacity: 1;
 }
 
 /* Agent back-link */
@@ -1997,6 +2004,7 @@ footer a {
 
 /* Toggle hide rules — driven by Alpine settings panel */
 .hide-thinking .thinking-block { display: none !important; }
+.hide-system-messages .message.system { display: none !important; }
 .hide-diffs .file-change .diff { display: none !important; }
 .hide-tool-inputs .tool-section-input { display: none !important; }
 /* Tools OFF: hide collapsible wrappers + section header + summaries, show inline fallbacks */
@@ -2012,6 +2020,7 @@ footer a {
 
 /* Prevent hidden elements from being chosen as scroll anchors */
 .thinking-block,
+.message.system,
 .tool-invocation-wrapper,
 .tool-section-input,
 .subagent-content,
@@ -2205,15 +2214,17 @@ input:checked + .toggle-switch::after {
             
             
             <div class="message user" id="msg-1">
-                <div class="message-header">
+                <details class="message-details" open>
+                <summary class="message-header">
+                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                     <div class="message-role">user</div>
                     
                     <span class="message-timestamp">2024-02-01 00:00:01</span>
                     
-                    <a href="#msg-1" class="message-anchor" title="Link to this message">#1</a>
+                    <a href="#msg-1" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#1</a>
                     
                     
-                </div>
+                </summary>
                 <div class="message-content">
                     
                     <div class="message-content-inner">
@@ -2237,6 +2248,7 @@ input:checked + .toggle-switch::after {
         
                     </div>
                 </div>
+                </details>
             </div>
             
             
@@ -2244,15 +2256,17 @@ input:checked + .toggle-switch::after {
             
             
             <div class="message assistant" id="msg-2">
-                <div class="message-header">
+                <details class="message-details" open>
+                <summary class="message-header">
+                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                     <div class="message-role">assistant</div>
                     
                     <span class="message-timestamp">2024-02-01 00:00:02</span>
                     
-                    <a href="#msg-2" class="message-anchor" title="Link to this message">#2</a>
+                    <a href="#msg-2" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#2</a>
                     
                     
-                </div>
+                </summary>
                 <div class="message-content">
                     
                     <div class="message-content-inner">
@@ -2276,9 +2290,9 @@ input:checked + .toggle-switch::after {
                         
                             
                             
-                            <details class="skill-block">
+                            <details class="skill-block" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="skill-badge-label">⚡ skill: <code>Loaded skill: azsafe</code></span>
                                 </summary>
                                 <div class="skill-content">Safe Azure CLI proxy for read-only commands.</div>
@@ -2287,9 +2301,9 @@ input:checked + .toggle-switch::after {
                             
                         
                             
-                            <details class="subagent-block">
+                            <details class="subagent-block" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="subagent-label">General Purpose Agent: Fix JWT token refresh bug</span>
                                     
                                     
@@ -2408,9 +2422,9 @@ input:checked + .toggle-switch::after {
                             
                             
                             <div class="content-block content-block-toolInvocation tool-invocation-inline">
-                                <details class="tool-invocation-wrapper">
+                                <details class="tool-invocation-wrapper" open>
                                     <summary>
-                                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                         <span class="tool-invocation-message">
                                             
                                                 Run auth tests
@@ -2508,9 +2522,9 @@ tests/test_auth.py::test_expired PASSED
                             
                         
                             
-                            <details class="subagent-block">
+                            <details class="subagent-block" open>
                                 <summary>
-                                    <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                                     <span class="subagent-label">Explore Agent: Verify fix in related files</span>
                                     
                                     
@@ -2624,6 +2638,7 @@ tests/test_auth.py::test_expired PASSED
         
                     </div>
                 </div>
+                </details>
             </div>
             
             
@@ -2649,7 +2664,7 @@ tests/test_auth.py::test_expired PASSED
                 }
             }
 
-            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block').forEach(details => {
+            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block, details.task-complete-block, details.subagent-block, details.subagent-prompt, details.thinking-block, details.system-message-details, details.message-details').forEach(details => {
                 details.addEventListener('toggle', function() {
                     const icon = this.querySelector(':scope > summary > .collapsible-icon');
                     if (icon) {

--- a/tests/snapshots/baselines/cli-with-async-shells.html
+++ b/tests/snapshots/baselines/cli-with-async-shells.html
@@ -438,6 +438,21 @@ header h1 {
     margin-bottom: 0;
 }
 
+.message-details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.message-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.message-details > summary .collapsible-icon {
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    line-height: 1;
+}
+
 .message-anchor {
     color: var(--text-secondary);
     text-decoration: none;
@@ -961,14 +976,6 @@ header h1 {
 .system-message-details > summary .collapsible-icon {
     display: inline-block;
     color: var(--text-secondary);
-}
-
-.system-message-details[open] > summary .collapsible-icon {
-    transform: rotate(90deg);
-}
-
-.expand-system-messages .system-message-details {
-    opacity: 1;
 }
 
 /* Agent back-link */
@@ -1997,6 +2004,7 @@ footer a {
 
 /* Toggle hide rules — driven by Alpine settings panel */
 .hide-thinking .thinking-block { display: none !important; }
+.hide-system-messages .message.system { display: none !important; }
 .hide-diffs .file-change .diff { display: none !important; }
 .hide-tool-inputs .tool-section-input { display: none !important; }
 /* Tools OFF: hide collapsible wrappers + section header + summaries, show inline fallbacks */
@@ -2012,6 +2020,7 @@ footer a {
 
 /* Prevent hidden elements from being chosen as scroll anchors */
 .thinking-block,
+.message.system,
 .tool-invocation-wrapper,
 .tool-section-input,
 .subagent-content,
@@ -2207,15 +2216,17 @@ input:checked + .toggle-switch::after {
             
             
             <div class="message assistant" id="msg-1">
-                <div class="message-header">
+                <details class="message-details" open>
+                <summary class="message-header">
+                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                     <div class="message-role">assistant</div>
                     
                     <span class="message-timestamp">2024-02-01 00:00:01</span>
                     
-                    <a href="#msg-1" class="message-anchor" title="Link to this message">#1</a>
+                    <a href="#msg-1" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#1</a>
                     
                     
-                </div>
+                </summary>
                 <div class="message-content">
                     
                     <div class="message-content-inner">
@@ -2241,9 +2252,9 @@ input:checked + .toggle-switch::after {
                             
                             
                             <div class="content-block content-block-toolInvocation tool-invocation-inline">
-                                <details class="tool-invocation-wrapper">
+                                <details class="tool-invocation-wrapper" open>
                                     <summary>
-                                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                         <span class="tool-invocation-message">
                                             
                                                 Check git status
@@ -2296,9 +2307,9 @@ M src/routes.ts</code></pre>
                             
                             
                             <div class="content-block content-block-toolInvocation tool-invocation-inline">
-                                <details class="tool-invocation-wrapper command-async" id="shell-dev-server">
+                                <details class="tool-invocation-wrapper command-async" id="shell-dev-server" open>
                                     <summary>
-                                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                         <span class="tool-invocation-message">
                                             
                                                 Start dev server
@@ -2475,6 +2486,7 @@ M src/routes.ts</code></pre>
         
                     </div>
                 </div>
+                </details>
             </div>
             
             
@@ -2482,15 +2494,17 @@ M src/routes.ts</code></pre>
             
             
             <div class="message user" id="msg-2">
-                <div class="message-header">
+                <details class="message-details" open>
+                <summary class="message-header">
+                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                     <div class="message-role">user</div>
                     
                     <span class="message-timestamp">2024-02-01 00:00:20</span>
                     
-                    <a href="#msg-2" class="message-anchor" title="Link to this message">#2</a>
+                    <a href="#msg-2" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#2</a>
                     
                     
-                </div>
+                </summary>
                 <div class="message-content">
                     
                     <div class="message-content-inner">
@@ -2514,6 +2528,7 @@ M src/routes.ts</code></pre>
         
                     </div>
                 </div>
+                </details>
             </div>
             
             
@@ -2521,15 +2536,17 @@ M src/routes.ts</code></pre>
             
             
             <div class="message assistant" id="msg-3">
-                <div class="message-header">
+                <details class="message-details" open>
+                <summary class="message-header">
+                    <span class="collapsible-icon" aria-hidden="true">▼</span>
                     <div class="message-role">assistant</div>
                     
                     <span class="message-timestamp">2024-02-01 00:00:21</span>
                     
-                    <a href="#msg-3" class="message-anchor" title="Link to this message">#3</a>
+                    <a href="#msg-3" class="message-anchor" title="Link to this message" onclick="event.stopPropagation()">#3</a>
                     
                     
-                </div>
+                </summary>
                 <div class="message-content">
                     
                     <div class="message-content-inner">
@@ -2604,9 +2621,9 @@ M src/routes.ts</code></pre>
                             
                             
                             <div class="content-block content-block-toolInvocation tool-invocation-inline">
-                                <details class="tool-invocation-wrapper command-async" id="shell-tsc-watch">
+                                <details class="tool-invocation-wrapper command-async" id="shell-tsc-watch" open>
                                     <summary>
-                                        <span class="collapsible-icon" aria-hidden="true">▶</span>
+                                       <span class="collapsible-icon" aria-hidden="true">▼</span>
                                         <span class="tool-invocation-message">
                                             
                                                 TypeScript watcher
@@ -2729,6 +2746,7 @@ M src/routes.ts</code></pre>
         
                     </div>
                 </div>
+                </details>
             </div>
             
             
@@ -2754,7 +2772,7 @@ M src/routes.ts</code></pre>
                 }
             }
 
-            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block').forEach(details => {
+            document.querySelectorAll('details.collapsible, details.tool-invocations-header, details.terminal-output-toggle, details.tool-invocation-wrapper, details.skill-block, details.task-complete-block, details.subagent-block, details.subagent-prompt, details.thinking-block, details.system-message-details, details.message-details').forEach(details => {
                 details.addEventListener('toggle', function() {
                     const icon = this.querySelector(':scope > summary > .collapsible-icon');
                     if (icon) {

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1560,6 +1560,43 @@ class TestGranularSearchContentSet:
         tool_hits_msgs = [r for r in results_msgs if r["match_type"] == "tool_invocation"]
         assert len(tool_hits_msgs) == 0
 
+    def test_message_search_excludes_system_messages_by_default(self, tmp_path):
+        """Default message search does not return system-role messages."""
+        db = Database(tmp_path / "system_search.db")
+        db.add_session(
+            ChatSession(
+                session_id="system-search-session",
+                workspace_name="system-search-project",
+                workspace_path="/tmp/system-search",
+                messages=[
+                    ChatMessage(role="user", content="hello"),
+                    ChatMessage(role="system", content="xyzzySystemSecret11 internal instructions"),
+                ],
+            )
+        )
+
+        results = db.search("xyzzySystemSecret11", search_content_set={"messages"})
+        assert results == []
+
+    def test_role_system_search_finds_system_messages(self, tmp_path):
+        """Explicit role=system search still returns system-role messages."""
+        db = Database(tmp_path / "system_search.db")
+        db.add_session(
+            ChatSession(
+                session_id="system-search-session",
+                workspace_name="system-search-project",
+                workspace_path="/tmp/system-search",
+                messages=[
+                    ChatMessage(role="user", content="hello"),
+                    ChatMessage(role="system", content="xyzzySystemSecret11 internal instructions"),
+                ],
+            )
+        )
+
+        results = db.search("xyzzySystemSecret11", role="system", search_content_set={"messages"})
+        assert len(results) == 1
+        assert results[0]["role"] == "system"
+
     # 2. Tools-only search
     def test_tools_only_search(self, rich_db):
         """search_content_set={'tools'} only returns tool invocation matches."""

--- a/tests/test_html_exporter.py
+++ b/tests/test_html_exporter.py
@@ -100,6 +100,7 @@ def session_with_thinking():
                         name="readFile",
                         input='{"path": "main.py"}',
                         result="def main(): pass",
+                        source_type="mcp",
                     ),
                 ],
             ),
@@ -147,6 +148,13 @@ class TestSessionToHtml:
         html = session_to_html(sample_session)
         assert "Hello, can you help me?" in html
         assert "Sure, I can help!" in html
+
+    def test_top_level_messages_are_collapsible_open_by_default(self, sample_session):
+        """User and assistant messages render as open-by-default details."""
+        html = session_to_html(sample_session)
+        assert html.count('<details class="message-details" open>') == 2
+        assert '<summary class="message-header">' in html
+        assert '<span class="collapsible-icon" aria-hidden="true">▼</span>' in html
 
     def test_fork_status_escaped_session_name_is_not_rendered_as_html(self):
         """Test that escaped fork link labels remain text when rendered as Markdown."""
@@ -245,7 +253,7 @@ class TestSessionToHtml:
         # Agent details should be included (full subagent content)
         assert "Found the root cause" in html
         # Thinking blocks should NOT be rendered (not in content_set)
-        assert '<details class="thinking-block">' not in html
+        assert '<details class="thinking-block" open>' not in html
 
     def test_session_to_html_content_set_none_uses_defaults(self, session_with_thinking):
         """content_set=None uses default includes."""
@@ -254,19 +262,19 @@ class TestSessionToHtml:
         # Default includes agent-details, so subagent content should be present
         assert "Found the root cause" in html
         # Default does NOT include 'thinking', so thinking elements not rendered
-        assert '<details class="thinking-block">' not in html
+        assert '<details class="thinking-block" open>' not in html
 
     def test_session_to_html_excludes_thinking(self, session_with_thinking):
         """Thinking blocks excluded when 'thinking' not in content_set."""
         html = session_to_html(session_with_thinking, content_set={"agent-details"})
-        assert '<details class="thinking-block">' not in html
+        assert '<details class="thinking-block" open>' not in html
         # But message text should still be present
         assert "investigate the issue" in html
 
     def test_session_to_html_includes_thinking_when_requested(self, session_with_thinking):
         """Thinking blocks included when 'thinking' IS in content_set."""
         html = session_to_html(session_with_thinking, content_set={"agent-details", "thinking"})
-        assert '<details class="thinking-block">' in html
+        assert '<details class="thinking-block" open>' in html
         assert "analyze the error" in html
 
     def test_session_to_html_excludes_agent_details(self, session_with_thinking):
@@ -284,20 +292,26 @@ class TestSessionToHtml:
         assert 'x-data="' not in html
         assert '<button class="settings-btn"' not in html
 
-    def test_system_messages_collapsed_by_default_in_static_export(self, session_with_system_message):
-        """System-role messages render as collapsed details by default."""
+    def test_system_messages_omitted_by_default_in_static_export(self, session_with_system_message):
+        """System-role messages are excluded from default static HTML exports."""
         html = session_to_html(session_with_system_message)
-        assert '<details class="system-message-details">' in html
-        assert '<span class="collapsible-icon" aria-hidden="true">▶</span>' in html
-        assert '<a href="#msg-2" class="message-anchor"' in html
-        assert "System instructions go here" in html
-        assert 'class="system-message-details" open' not in html
+        assert '<div class="message system"' not in html
+        assert "System instructions go here" not in html
 
-    def test_system_messages_expand_when_included(self, session_with_system_message):
-        """Including system-messages opens system details by default in static export."""
+    def test_system_messages_included_open_by_default(self, session_with_system_message):
+        """Including system-messages renders open collapsible details in static export."""
         html = session_to_html(session_with_system_message, content_set={"agent-details", "tools", "commands", "file-changes", "system-messages"})
-        assert 'class="system-message-details" open' in html
-        assert "expand-system-messages" in html
+        assert 'class="message-details system-message-details" open' in html
+        assert '<span class="collapsible-icon" aria-hidden="true">▼</span>' in html
+        assert "System instructions go here" in html
+        assert "expand-system-messages" not in html
+
+    def test_auxiliary_sections_are_collapsible_open_by_default(self, session_with_thinking):
+        """Representative auxiliary HTML sections render as open-by-default details."""
+        html = session_to_html(session_with_thinking, content_set={"agent-details", "thinking", "tools"})
+        assert '<details class="thinking-block" open>' in html
+        assert '<details class="subagent-block" open>' in html
+        assert '<details class="tool-invocation-wrapper" open>' in html
 
 
 class TestExportSessionToHtmlFile:

--- a/tests/test_toggle_edge_cases.py
+++ b/tests/test_toggle_edge_cases.py
@@ -177,7 +177,7 @@ class TestHtmlToggleCombinations:
         session = _make_session()
         html = session_to_html(session, content_set={"agent-details", "tools"})
         # Thinking content block elements are stripped server-side
-        assert '<details class="thinking-block">' not in html
+        assert '<details class="thinking-block" open>' not in html
         # CSS hide class is still applied to body for belt-and-suspenders hiding
         assert "hide-thinking" in html
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -264,23 +264,31 @@ class TestWebappRoutes:
         assert response.status_code == 200
         assert b"What is Python?" in response.data
 
-    def test_session_hides_system_messages_toggle(self, client):
-        """System messages are always present and not a user-toggle option."""
+    def test_session_top_level_messages_are_collapsible(self, client):
+        """User and assistant messages render as open-by-default details."""
         response = client.get("/session/webapp-test-session")
         assert response.status_code == 200
         html = response.data.decode("utf-8")
-        assert "System messages" not in html
-        assert 'x-model="systemMessages"' not in html
+        assert html.count('<details class="message-details" open>') == 2
+        assert '<summary class="message-header">' in html
 
-    def test_session_content_set_always_includes_system_messages(self, client):
-        """Web-viewer exports always include system messages in content_set."""
+    def test_session_exposes_system_messages_toggle(self, client):
+        """System messages are available as an explicit content option."""
         response = client.get("/session/webapp-test-session")
         assert response.status_code == 200
         html = response.data.decode("utf-8")
-        assert "set.push('system-messages');" in html
+        assert "System messages" in html
+        assert 'x-model="systemMessages"' in html
 
-    def test_session_system_messages_collapsed_by_default(self, temp_db):
-        """System-message parent blocks render collapsed by default in web view."""
+    def test_session_content_set_omits_system_messages_by_default(self, client):
+        """Web-viewer export content sets omit system messages unless toggled."""
+        response = client.get("/session/webapp-test-session")
+        assert response.status_code == 200
+        html = response.data.decode("utf-8")
+        assert "if (this.systemMessages) set.push('system-messages');" in html
+
+    def test_session_system_messages_open_by_default(self, temp_db):
+        """System-message parent blocks render open by default in web view."""
         db = Database(temp_db)
         session = ChatSession(
             session_id="webapp-system-session",
@@ -302,8 +310,7 @@ class TestWebappRoutes:
 
         assert response.status_code == 200
         html = response.data.decode("utf-8")
-        assert '<details class="system-message-details">' in html
-        assert 'class="system-message-details" open' not in html
+        assert '<details class="message-details system-message-details" open>' in html
 
     def test_session_shows_root_agent_transition_pills(self, temp_db):
         """Root custom-agent intervals render as timeline transition pills."""

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
- Make top-level User, Assistant, and included System messages collapsible while open by default
- Make representative auxiliary HTML sections collapsible without changing default visibility semantics
- Treat `system-messages` as an optional CONTENT flag excluded from default exports and default search, while preserving explicit `role=system` search
- Bump package version to 0.14.0 and update affected tests/snapshots

## Validation
- `uv run pytest tests/test_html_exporter.py tests/test_webapp.py tests/test_toggle_edge_cases.py tests/test_snapshot.py -v`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- Full suite earlier in this PR prep: `uv run pytest` (`855 passed, 13 skipped`)
- Visual screenshots reviewed for CONTENT toggle, system open, system closed, and system missing states