### PR TITLE
feat: track multi-repository session context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,28 @@
+> Created/edited by GitHub Copilot with human review/feedback by avilevin.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.15.0] - 2026-06-02
+
+### Added
+
+- **Scanner / Database**: Track context history for sessions that change working directory or repository over time, while preserving the original scalar workspace/repository fields as the primary context.
+- **Search**: Workspace and repository filters now match the context active at each search hit, with repeated `workspace:` and `repo:` filters treated as OR within the same filter kind.
+- **Web Viewer**: Search-result snippets show the active workspace/repository only when it differs from the session's root context.
+
+### Changed
+
+- **Web Viewer / HTML Export**: Working-directory changes render inline as transcript status pills instead of a session-level "context changed N times" summary.
+- **Markdown Export**: Metadata now includes the primary repository without adding a separate context-history summary.
+
+### Fixed
+
+- **Scanner**: Recognize the current Chronicle session-store schema version so scans no longer warn for schema v4 stores.
 
 ## [0.14.0] - 2026-06-02
 
@@ -17,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Search**: Message searches exclude system-role messages by default unless an explicit role filter, such as `role=system`, is provided.
 
-## [0.13.0] - 2026-05-29
+## [0.13.0] - 2026-05-31
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.14.0"
+version = "0.15.0"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 from .content_types import (
     CONTENT_TYPES,
@@ -41,6 +41,7 @@ from .scanner import (
     ContentBlock,
     FileChange,
     RootAgentInterval,
+    SessionContextEntry,
     ToolInvocation,
     detect_repository_url,
     find_copilot_chat_dirs,
@@ -64,6 +65,7 @@ __all__ = [
     "FileChange",
     "ParsedQuery",
     "RootAgentInterval",
+    "SessionContextEntry",
     "ToolInvocation",
     # Package
     "__version__",

--- a/src/copilot_session_tools/database.py
+++ b/src/copilot_session_tools/database.py
@@ -53,6 +53,7 @@ class Database:
         "cst_file_changes",
         "cst_tool_invocations",
         "cst_root_agent_intervals",
+        "cst_session_contexts",
         "cst_messages",
         "cst_sessions",
     ]
@@ -465,7 +466,7 @@ class Database:
         include_file_changes: bool | None = None,
         session_title: str | None = None,
         sort_by: str = "relevance",
-        repository: str | None = None,
+        repository: str | list[str] | None = None,
         start_date: str | None = None,
         end_date: str | None = None,
     ) -> list[dict]:

--- a/src/copilot_session_tools/db_retrieval.py
+++ b/src/copilot_session_tools/db_retrieval.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import contextlib
 import sqlite3
 
-from .db_schema import row_to_command, row_to_file_change, row_to_root_agent_interval, row_to_tool
+from .db_schema import row_to_command, row_to_file_change, row_to_root_agent_interval, row_to_session_context, row_to_tool
 from .markdown_exporter import message_to_markdown
 from .scanner import (
     ChatMessage,
@@ -65,6 +65,53 @@ def _link_child_messages(
             parent_msg.content_blocks[block_idx].file_changes = child_msg.file_changes
             parent_msg.content_blocks[block_idx].command_runs = child_msg.command_runs
             parent_msg.children.append(child_msg)
+
+
+def _session_contexts_for_ids(conn: sqlite3.Connection, session_ids: list[str]) -> dict[str, list[dict]]:
+    """Return context-history dictionaries keyed by session id."""
+    if not session_ids:
+        return {}
+    placeholders = ",".join("?" * len(session_ids))
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT session_id, context_index, message_index, timestamp, workspace_name,
+                   workspace_path, repository_url, branch, source
+            FROM cst_session_contexts
+            WHERE session_id IN ({placeholders})
+            ORDER BY session_id, context_index
+            """,  # noqa: S608
+            session_ids,
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+
+    contexts: dict[str, list[dict]] = {}
+    for row in rows:
+        contexts.setdefault(row["session_id"], []).append(dict(row))
+    return contexts
+
+
+def _apply_context_lists(session: dict, contexts: list[dict] | None) -> None:
+    """Attach context history and aggregate workspace/repository lists to a session dict."""
+    context_entries = contexts or []
+    if not context_entries and (session.get("workspace_name") or session.get("workspace_path") or session.get("repository_url")):
+        context_entries = [
+            {
+                "context_index": 0,
+                "message_index": 0,
+                "timestamp": session.get("created_at"),
+                "workspace_name": session.get("workspace_name"),
+                "workspace_path": session.get("workspace_path"),
+                "repository_url": session.get("repository_url"),
+                "branch": None,
+                "source": "initial",
+            }
+        ]
+    session["context_entries"] = context_entries
+    session["workspace_names"] = list(dict.fromkeys(c["workspace_name"] for c in context_entries if c.get("workspace_name")))
+    session["workspace_paths"] = list(dict.fromkeys(c["workspace_path"] for c in context_entries if c.get("workspace_path")))
+    session["repository_urls"] = list(dict.fromkeys(c["repository_url"] for c in context_entries if c.get("repository_url")))
 
 
 def reconstruct_message(
@@ -203,6 +250,14 @@ def get_cst_session(conn: sqlite3.Connection, session_id: str) -> ChatSession | 
         )
         root_agent_intervals = [row_to_root_agent_interval(r) for r in cursor.fetchall()]
 
+    context_entries = []
+    with contextlib.suppress(sqlite3.OperationalError):
+        cursor.execute(
+            "SELECT * FROM cst_session_contexts WHERE session_id = ? ORDER BY context_index",
+            (session_id,),
+        )
+        context_entries = [row_to_session_context(r) for r in cursor.fetchall()]
+
     # --- Reconstruct messages from pre-fetched data ---
     messages_by_id: dict[int, ChatMessage] = {}
     content_block_child_ids: dict[int, dict[int, int]] = {}
@@ -293,6 +348,7 @@ def get_cst_session(conn: sqlite3.Connection, session_id: str) -> ChatSession | 
         type=safe_get("type") or "vscode",
         repository_url=safe_get("repository_url"),
         root_agent_intervals=root_agent_intervals,
+        context_entries=context_entries,
     )
 
 
@@ -630,8 +686,16 @@ def list_sessions(
         params: list = []
 
         if workspace_name:
-            conditions.append("s.workspace_name = ?")
-            params.append(workspace_name)
+            conditions.append(
+                """(
+                    s.workspace_name = ?
+                    OR EXISTS (
+                        SELECT 1 FROM cst_session_contexts sc
+                        WHERE sc.session_id = s.session_id AND sc.workspace_name = ?
+                    )
+                )"""
+            )
+            params.extend([workspace_name, workspace_name])
         if session_type:
             conditions.append("s.type = ?")
             params.append(session_type)
@@ -642,8 +706,11 @@ def list_sessions(
         query += " GROUP BY s.session_id HAVING COUNT(CASE WHEN m.parent_message_id IS NULL THEN 1 END) > 0 ORDER BY last_message_at DESC, s.created_at DESC"
 
         cursor.execute(query, params)
-        for row in cursor.fetchall():
+        rows = cursor.fetchall()
+        contexts_by_session = _session_contexts_for_ids(conn, [row["session_id"] for row in rows])
+        for row in rows:
             d = dict(row)
+            _apply_context_lists(d, contexts_by_session.get(d["session_id"]))
             d["title"] = d.get("custom_title") or d.get("workspace_name")
             d["start_time"] = d.get("created_at")
             d["is_enriched"] = True
@@ -694,6 +761,7 @@ def list_sessions(
                     "last_message_at": row.get("updated_at"),
                     "first_user_prompt": None,
                 }
+                _apply_context_lists(results[sid], None)
 
     # Sort by updated_at desc, apply limit/offset
     sorted_results = sorted(results.values(), key=lambda x: x.get("updated_at") or "", reverse=True)
@@ -716,9 +784,22 @@ def get_workspaces(conn: sqlite3.Connection) -> list[dict]:
         SELECT
             workspace_name,
             workspace_path,
-            COUNT(*) as session_count,
+            COUNT(DISTINCT session_id) as session_count,
             MAX(created_at) as last_activity
-        FROM cst_sessions
+        FROM (
+            SELECT sc.session_id, sc.workspace_name, sc.workspace_path, s.created_at
+            FROM cst_session_contexts sc
+            JOIN cst_sessions s ON s.session_id = sc.session_id
+            WHERE sc.workspace_name IS NOT NULL
+            UNION ALL
+            SELECT session_id, workspace_name, workspace_path, created_at
+            FROM cst_sessions
+            WHERE workspace_name IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM cst_session_contexts sc
+                  WHERE sc.session_id = cst_sessions.session_id
+              )
+        )
         WHERE workspace_name IS NOT NULL
         GROUP BY workspace_name, workspace_path
         ORDER BY session_count DESC, workspace_name ASC
@@ -741,9 +822,22 @@ def get_repositories(conn: sqlite3.Connection) -> list[dict]:
         """
         SELECT
             repository_url,
-            COUNT(*) as session_count,
+            COUNT(DISTINCT session_id) as session_count,
             MAX(created_at) as last_activity
-        FROM cst_sessions
+        FROM (
+            SELECT sc.session_id, sc.repository_url, s.created_at
+            FROM cst_session_contexts sc
+            JOIN cst_sessions s ON s.session_id = sc.session_id
+            WHERE sc.repository_url IS NOT NULL
+            UNION ALL
+            SELECT session_id, repository_url, created_at
+            FROM cst_sessions
+            WHERE repository_url IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM cst_session_contexts sc
+                  WHERE sc.session_id = cst_sessions.session_id
+              )
+        )
         WHERE repository_url IS NOT NULL
         GROUP BY repository_url
         ORDER BY session_count DESC, repository_url ASC

--- a/src/copilot_session_tools/db_schema.py
+++ b/src/copilot_session_tools/db_schema.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import sqlite3
 
-from .scanner import ChatSession, CommandRun, FileChange, RootAgentInterval, ToolInvocation
+from .scanner import ChatSession, CommandRun, FileChange, RootAgentInterval, SessionContextEntry, ToolInvocation
 
 # ---------------------------------------------------------------------------
 # Column tuples used in INSERT statements (order matters for parameterized queries)
@@ -108,6 +108,18 @@ CST_ROOT_AGENT_INTERVAL_COLUMNS = (
     "start_timestamp",
     "end_timestamp",
     "tools_json",
+)
+
+CST_SESSION_CONTEXT_COLUMNS = (
+    "session_id",
+    "context_index",
+    "message_index",
+    "timestamp",
+    "workspace_name",
+    "workspace_path",
+    "repository_url",
+    "branch",
+    "source",
 )
 
 # ---------------------------------------------------------------------------
@@ -220,6 +232,21 @@ def root_agent_interval_to_row(session_id: str, interval: RootAgentInterval) -> 
     )
 
 
+def session_context_to_row(session_id: str, context_index: int, entry: SessionContextEntry) -> tuple:
+    """Map a SessionContextEntry to a parameter tuple matching CST_SESSION_CONTEXT_COLUMNS."""
+    return (
+        session_id,
+        context_index,
+        entry.message_index,
+        entry.timestamp,
+        entry.workspace_name,
+        entry.workspace_path,
+        entry.repository_url,
+        entry.branch,
+        entry.source,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Row → dataclass helpers  (read path)
 # ---------------------------------------------------------------------------
@@ -259,6 +286,19 @@ def row_to_root_agent_interval(row: sqlite3.Row) -> RootAgentInterval:
         start_timestamp=row["start_timestamp"],
         end_timestamp=row["end_timestamp"],
         tools=tools,
+    )
+
+
+def row_to_session_context(row: sqlite3.Row) -> SessionContextEntry:
+    """Map a cst_session_contexts row to a SessionContextEntry."""
+    return SessionContextEntry(
+        workspace_name=row["workspace_name"],
+        workspace_path=row["workspace_path"],
+        repository_url=row["repository_url"],
+        branch=row["branch"],
+        timestamp=row["timestamp"],
+        message_index=row["message_index"],
+        source=row["source"],
     )
 
 

--- a/src/copilot_session_tools/db_search.py
+++ b/src/copilot_session_tools/db_search.py
@@ -20,8 +20,10 @@ class ParsedQuery:
     fts_query: str  # The FTS5 query string for content search
     role: str | None = None  # Extracted role filter (user/assistant)
     workspace: str | None = None  # Extracted workspace filter
+    workspaces: list[str] | None = None  # All extracted workspace filters
     title: str | None = None  # Extracted title filter
     repository: str | None = None  # Extracted repository filter
+    repositories: list[str] | None = None  # All extracted repository filters
     edition: str | None = None  # Extracted edition filter (stable/insider/cli)
     start_date: str | None = None  # Extracted start date filter (yyyy-mm-dd format, inclusive)
     end_date: str | None = None  # Extracted end date filter (yyyy-mm-dd format, inclusive)
@@ -113,9 +115,9 @@ def parse_search_query(query: str) -> ParsedQuery:
 
     # Extract field prefixes (role:, workspace:, title:, repository:, edition:, start_date:, end_date:)
     role = None
-    workspace = None
+    workspaces: list[str] = []
     title = None
-    repository = None
+    repositories: list[str] = []
     edition = None
     start_date = None
     end_date = None
@@ -124,7 +126,7 @@ def parse_search_query(query: str) -> ParsedQuery:
     field_pattern = r'\b(role|workspace|title|repository|repo|edition|start_date|end_date):(?:"([^"]*)"|(\S+))'
 
     def extract_field(match):
-        nonlocal role, workspace, title, repository, edition, start_date, end_date
+        nonlocal role, title, edition, start_date, end_date
         field_name = match.group(1).lower()
         # Value is either in group 2 (quoted) or group 3 (unquoted)
         value = match.group(2) if match.group(2) is not None else match.group(3)
@@ -132,11 +134,11 @@ def parse_search_query(query: str) -> ParsedQuery:
         if field_name == "role":
             role = value.lower()
         elif field_name == "workspace":
-            workspace = value
+            workspaces.append(value)
         elif field_name == "title":
             title = value
         elif field_name in ("repository", "repo"):
-            repository = value
+            repositories.append(value)
         elif field_name == "edition":
             edition = value.lower()
         elif field_name == "start_date":
@@ -182,9 +184,11 @@ def parse_search_query(query: str) -> ParsedQuery:
     return ParsedQuery(
         fts_query=fts_query,
         role=role,
-        workspace=workspace,
+        workspace=workspaces[0] if workspaces else None,
+        workspaces=workspaces or None,
         title=title,
-        repository=repository,
+        repository=repositories[0] if repositories else None,
+        repositories=repositories or None,
         edition=edition,
         start_date=start_date,
         end_date=end_date,
@@ -265,14 +269,37 @@ _SORT_ORDER_CLAUSES = {
 }
 
 
+def _active_context_index_subquery() -> str:
+    """Return SQL that selects the context active at the current message row."""
+    return """
+        COALESCE(
+            (
+                SELECT sc2.context_index
+                FROM cst_session_contexts sc2
+                WHERE sc2.session_id = s.session_id
+                  AND sc2.message_index <= COALESCE(m.message_index, 0)
+                ORDER BY sc2.message_index DESC, sc2.context_index DESC
+                LIMIT 1
+            ),
+            (
+                SELECT sc3.context_index
+                FROM cst_session_contexts sc3
+                WHERE sc3.session_id = s.session_id
+                ORDER BY sc3.message_index ASC, sc3.context_index ASC
+                LIMIT 1
+            )
+        )
+    """
+
+
 def _append_session_filters(
     query: str,
     params: list,
     *,
     include_agent_content: bool,
-    effective_workspace: str | None,
+    effective_workspaces: list[str],
     effective_title: str | None,
-    effective_repository: str | None,
+    effective_repositories: list[str],
     effective_edition: str | None,
     effective_start_date: str | None,
     effective_end_date: str | None,
@@ -285,9 +312,9 @@ def _append_session_filters(
         query: The SQL query string to append to.
         params: The parameter list (modified in-place).
         include_agent_content: Whether to include agent/subagent content.
-        effective_workspace: Workspace filter value.
+        effective_workspaces: Workspace filter values.
         effective_title: Title filter value.
-        effective_repository: Repository filter value.
+        effective_repositories: Repository filter values.
         effective_edition: Edition filter value.
         effective_start_date: Start date filter.
         effective_end_date: End date filter.
@@ -298,17 +325,59 @@ def _append_session_filters(
     if not include_agent_content:
         query += " AND m.agent_nesting_level = 0"
 
-    if effective_workspace:
-        query += " AND s.workspace_name LIKE ?"
-        params.append(f"%{effective_workspace}%")
+    if effective_workspaces:
+        clauses = []
+        active_context_index = _active_context_index_subquery()
+        for workspace in effective_workspaces:
+            clauses.append(
+                f"""(
+                    (
+                        NOT EXISTS (
+                            SELECT 1 FROM cst_session_contexts sc_any
+                            WHERE sc_any.session_id = s.session_id
+                        )
+                        AND (s.workspace_name LIKE ? OR s.workspace_path LIKE ?)
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM cst_session_contexts sc
+                        WHERE sc.session_id = s.session_id
+                          AND sc.context_index = ({active_context_index})
+                          AND (sc.workspace_name LIKE ? OR sc.workspace_path LIKE ?)
+                    )
+                )"""  # noqa: S608 -- interpolates static active-context SQL only
+            )
+            like_value = f"%{workspace}%"
+            params.extend([like_value, like_value, like_value, like_value])
+        query += " AND (" + " OR ".join(clauses) + ")"
 
     if effective_title:
         query += " AND (s.workspace_name LIKE ? OR s.custom_title LIKE ?)"
         params.extend([f"%{effective_title}%", f"%{effective_title}%"])
 
-    if effective_repository:
-        query += " AND s.repository_url LIKE ?"
-        params.append(f"%{effective_repository}%")
+    if effective_repositories:
+        clauses = []
+        active_context_index = _active_context_index_subquery()
+        for repository in effective_repositories:
+            clauses.append(
+                f"""(
+                    (
+                        NOT EXISTS (
+                            SELECT 1 FROM cst_session_contexts sc_any
+                            WHERE sc_any.session_id = s.session_id
+                        )
+                        AND s.repository_url LIKE ?
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM cst_session_contexts sc
+                        WHERE sc.session_id = s.session_id
+                          AND sc.context_index = ({active_context_index})
+                          AND sc.repository_url LIKE ?
+                    )
+                )"""  # noqa: S608 -- interpolates static active-context SQL only
+            )
+            like_value = f"%{repository}%"
+            params.extend([like_value, like_value])
+        query += " AND (" + " OR ".join(clauses) + ")"
 
     if effective_edition:
         query += " AND s.vscode_edition = ?"
@@ -355,6 +424,53 @@ def _search_builtin_index(conn: sqlite3.Connection, fts_query: str, limit: int) 
     except Exception:  # noqa: S110
         pass  # search_index might not exist or chronicle not attached
     return builtin_results
+
+
+def _attach_active_contexts(conn: sqlite3.Connection, results: list[dict]) -> None:
+    """Attach the session context active at each search hit's message index."""
+    session_ids = list({r["session_id"] for r in results if r.get("session_id")})
+    if not session_ids:
+        return
+    placeholders = ",".join("?" * len(session_ids))
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT session_id, context_index, message_index, timestamp, workspace_name,
+                   workspace_path, repository_url, branch, source
+            FROM cst_session_contexts
+            WHERE session_id IN ({placeholders})
+            ORDER BY session_id, message_index, context_index
+            """,  # noqa: S608
+            session_ids,
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return
+
+    contexts_by_session: dict[str, list[dict]] = {}
+    for row in rows:
+        contexts_by_session.setdefault(row["session_id"], []).append(dict(row))
+
+    for result in results:
+        session_id = result.get("session_id")
+        if not isinstance(session_id, str):
+            continue
+        contexts = contexts_by_session.get(session_id, [])
+        if not contexts:
+            continue
+        message_index = result.get("message_index")
+        if message_index is None:
+            active = contexts[0]
+        else:
+            active = contexts[0]
+            for context in contexts:
+                if context.get("message_index", 0) <= message_index:
+                    active = context
+                else:
+                    break
+        result["active_context"] = active
+        result["workspace_name"] = active.get("workspace_name") or result.get("workspace_name")
+        result["workspace_path"] = active.get("workspace_path")
+        result["repository_url"] = active.get("repository_url")
 
 
 def _search_messages(
@@ -632,7 +748,7 @@ def execute_search(
     search_content_set: set[str],
     session_title: str | None = None,
     sort_by: str = "relevance",
-    repository: str | None = None,
+    repository: str | list[str] | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
     has_chronicle: bool = False,
@@ -677,8 +793,13 @@ def execute_search(
     # Use parsed field filters, with explicit parameters taking precedence
     effective_role = role if role else parsed.role
     effective_title = session_title if session_title else parsed.title
-    effective_workspace = parsed.workspace
-    effective_repository = repository if repository else parsed.repository
+    effective_workspaces = parsed.workspaces or []
+    if isinstance(repository, list):
+        effective_repositories = [repo for repo in repository if repo]
+    elif repository:
+        effective_repositories = [repository]
+    else:
+        effective_repositories = parsed.repositories or []
     effective_edition = parsed.edition
     effective_start_date = start_date if start_date else parsed.start_date
     effective_end_date = end_date if end_date else parsed.end_date
@@ -688,9 +809,9 @@ def execute_search(
     # Common filter kwargs shared across all content-type search branches
     filter_kwargs = {
         "include_agent_content": include_agent_content,
-        "effective_workspace": effective_workspace,
+        "effective_workspaces": effective_workspaces,
         "effective_title": effective_title,
-        "effective_repository": effective_repository,
+        "effective_repositories": effective_repositories,
         "effective_edition": effective_edition,
         "effective_start_date": effective_start_date,
         "effective_end_date": effective_end_date,
@@ -701,7 +822,7 @@ def execute_search(
     if has_chronicle and fts_query and include_msgs:
         builtin_results = _search_builtin_index(conn, fts_query, limit)
 
-    has_filters = bool(effective_role or effective_title or effective_workspace or effective_repository or effective_edition or effective_start_date or effective_end_date)
+    has_filters = bool(effective_role or effective_title or effective_workspaces or effective_repositories or effective_edition or effective_start_date or effective_end_date)
 
     cursor = conn.cursor()
 
@@ -771,6 +892,8 @@ def execute_search(
     for sid, builtin_row in builtin_results.items():
         if sid not in cst_session_ids:
             results.append(builtin_row)
+
+    _attach_active_contexts(conn, results)
 
     # Apply skip/limit to merged results for correct pagination
     return results[skip : skip + limit]

--- a/src/copilot_session_tools/db_storage.py
+++ b/src/copilot_session_tools/db_storage.py
@@ -18,18 +18,21 @@ from .db_schema import (
     CST_MESSAGE_COLUMNS,
     CST_ROOT_AGENT_INTERVAL_COLUMNS,
     CST_SESSION_COLUMNS,
+    CST_SESSION_CONTEXT_COLUMNS,
     CST_TOOL_INVOCATION_COLUMNS,
     command_to_row,
     file_change_to_row,
     insert_sql,
     root_agent_interval_to_row,
+    session_context_to_row,
     session_to_row,
     tool_to_row,
 )
 from .markdown_exporter import message_to_markdown
 from .scanner import ChatSession
 
-CST_SCHEMA_VERSION = 9
+CST_SCHEMA_VERSION = 10
+CHRONICLE_SCHEMA_VERSION = 4
 
 
 CST_SCHEMA = """
@@ -146,6 +149,24 @@ CREATE TABLE IF NOT EXISTS cst_root_agent_intervals (
 );
 CREATE INDEX IF NOT EXISTS idx_cst_root_agent_intervals_session ON cst_root_agent_intervals(session_id, start_timestamp);
 CREATE INDEX IF NOT EXISTS idx_cst_root_agent_intervals_agent ON cst_root_agent_intervals(agent_name);
+
+CREATE TABLE IF NOT EXISTS cst_session_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES cst_sessions(session_id) ON DELETE CASCADE,
+    context_index INTEGER NOT NULL,
+    message_index INTEGER NOT NULL DEFAULT 0,
+    timestamp TEXT,
+    workspace_name TEXT,
+    workspace_path TEXT,
+    repository_url TEXT,
+    branch TEXT,
+    source TEXT NOT NULL DEFAULT 'initial',
+    UNIQUE(session_id, context_index)
+);
+CREATE INDEX IF NOT EXISTS idx_cst_session_contexts_session ON cst_session_contexts(session_id, context_index);
+CREATE INDEX IF NOT EXISTS idx_cst_session_contexts_workspace_name ON cst_session_contexts(workspace_name);
+CREATE INDEX IF NOT EXISTS idx_cst_session_contexts_workspace_path ON cst_session_contexts(workspace_path);
+CREATE INDEX IF NOT EXISTS idx_cst_session_contexts_repo ON cst_session_contexts(repository_url);
 
 CREATE VIEW IF NOT EXISTS cst_messages_tree AS
 SELECT
@@ -291,6 +312,7 @@ def _drop_and_recreate_cst_tables(conn: sqlite3.Connection) -> None:
         "cst_file_changes",
         "cst_tool_invocations",
         "cst_root_agent_intervals",
+        "cst_session_contexts",
         "cst_messages",
         "cst_sessions",
         "cst_schema_version",
@@ -366,6 +388,9 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         # v8 → v9: Add root custom-agent interval storage and views.
         if current_version < 9:
             conn.executescript(CST_SCHEMA)
+        # v9 → v10: Add session context history storage.
+        if current_version < 10:
+            conn.executescript(CST_SCHEMA)
         cursor.execute(
             "UPDATE cst_schema_version SET version = ?",
             (CST_SCHEMA_VERSION,),
@@ -379,11 +404,12 @@ def check_builtin_schema_version(conn: sqlite3.Connection) -> None:
     """
     try:
         row = conn.execute("SELECT version FROM chronicle.schema_version LIMIT 1").fetchone()
-        if row and row[0] > 1:
+        if row and row[0] > CHRONICLE_SCHEMA_VERSION:
             import warnings
 
             warnings.warn(
-                f"Session store schema version {row[0]} is newer than expected (1). Some features may not work correctly. Consider updating copilot-session-tools.",
+                f"Session store schema version {row[0]} is newer than expected ({CHRONICLE_SCHEMA_VERSION}). "
+                "Some features may not work correctly. Consider updating copilot-session-tools.",
                 stacklevel=2,
             )
     except Exception:  # noqa: S110
@@ -491,6 +517,7 @@ def _delete_session_data(cursor: sqlite3.Cursor, session_id: str) -> None:
     )
     cursor.execute("DELETE FROM cst_messages_fts WHERE session_id = ?", (session_id,))
     cursor.execute("DELETE FROM cst_root_agent_intervals WHERE session_id = ?", (session_id,))
+    cursor.execute("DELETE FROM cst_session_contexts WHERE session_id = ?", (session_id,))
     cursor.execute("DELETE FROM cst_messages WHERE session_id = ?", (session_id,))
 
 
@@ -627,6 +654,12 @@ def add_session_impl(cursor: sqlite3.Cursor, session: ChatSession) -> None:
         cursor.execute(
             insert_sql("cst_root_agent_intervals", CST_ROOT_AGENT_INTERVAL_COLUMNS),
             root_agent_interval_to_row(session.session_id, interval),
+        )
+
+    for context_index, entry in enumerate(session.effective_context_entries()):
+        cursor.execute(
+            insert_sql("cst_session_contexts", CST_SESSION_CONTEXT_COLUMNS),
+            session_context_to_row(session.session_id, context_index, entry),
         )
 
     # Insert messages and related data
@@ -816,7 +849,9 @@ def update_enrichment_version(conn: sqlite3.Connection, session_id: str, version
 
 def delete_cst_session(conn: sqlite3.Connection, session_id: str) -> bool:
     """Delete all cst_* data for a session. Returns True if session existed."""
-    cursor = conn.execute("DELETE FROM cst_sessions WHERE session_id = ?", (session_id,))
+    db_cursor = conn.cursor()
+    _delete_session_data(db_cursor, session_id)
+    cursor = db_cursor.execute("DELETE FROM cst_sessions WHERE session_id = ?", (session_id,))
     return cursor.rowcount > 0
 
 
@@ -926,6 +961,12 @@ def enrich_session(conn: sqlite3.Connection, session: ChatSession) -> None:
             root_agent_interval_to_row(session.session_id, interval),
         )
 
+    for context_index, entry in enumerate(session.effective_context_entries()):
+        cursor.execute(
+            insert_sql("cst_session_contexts", CST_SESSION_CONTEXT_COLUMNS),
+            session_context_to_row(session.session_id, context_index, entry),
+        )
+
     # Insert messages and related data
     for idx, msg in enumerate(session.messages):
         cached_markdown = message_to_markdown(
@@ -1019,8 +1060,7 @@ def cleanup_orphaned_cst_sessions(conn: sqlite3.Connection, *, has_chronicle: bo
 
     # Delete orphaned sessions and all related data
     for session_id in orphaned_ids:
-        cursor.execute("DELETE FROM cst_messages_fts WHERE session_id = ?", (session_id,))
-        cursor.execute("DELETE FROM cst_messages WHERE session_id = ?", (session_id,))
+        _delete_session_data(cursor, session_id)
         cursor.execute("DELETE FROM cst_sessions WHERE session_id = ?", (session_id,))
 
     return orphaned_ids

--- a/src/copilot_session_tools/markdown_exporter.py
+++ b/src/copilot_session_tools/markdown_exporter.py
@@ -274,6 +274,9 @@ def session_to_markdown(
         decoded_path = _urldecode(session.workspace_path)
         lines.append(f"- **Path:** `{decoded_path}`")
 
+    if session.repository_url:
+        lines.append(f"- **Repository:** {session.repository_url}")
+
     if session.created_at:
         lines.append(f"- **Created:** {_format_timestamp(session.created_at)}")
 

--- a/src/copilot_session_tools/scanner/__init__.py
+++ b/src/copilot_session_tools/scanner/__init__.py
@@ -33,6 +33,7 @@ from .models import (
     ContentBlock,
     FileChange,
     RootAgentInterval,
+    SessionContextEntry,
     SessionFileInfo,
     ToolInvocation,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "ContentBlock",
     "FileChange",
     "RootAgentInterval",
+    "SessionContextEntry",
     "SessionFileInfo",
     "ToolInvocation",
     "_apply_jsonl_operations",

--- a/src/copilot_session_tools/scanner/cli.py
+++ b/src/copilot_session_tools/scanner/cli.py
@@ -11,13 +11,14 @@ import ssrjson
 from copilot_session_tools.scanner import PARSER_VERSION
 
 from .content import _format_tool_display_message, _get_file_metadata
-from .git import detect_repository_url
+from .git import _normalize_git_url, detect_repository_url
 from .models import (
     ChatMessage,
     ChatSession,
     CommandRun,
     ContentBlock,
     RootAgentInterval,
+    SessionContextEntry,
     ShellIOEntry,
     ToolInvocation,
 )
@@ -283,6 +284,38 @@ def _parse_workspace_yaml(session_dir: Path) -> dict[str, str]:
         return result
     except OSError:
         return {}
+
+
+def _workspace_name_from_path(workspace_path: str | None) -> str | None:
+    return Path(workspace_path).name if workspace_path else None
+
+
+def _append_context_entry(
+    entries: list[SessionContextEntry],
+    *,
+    workspace_path: str | None,
+    repository_url: str | None,
+    branch: str | None = None,
+    timestamp: str | None = None,
+    message_index: int = 0,
+    source: str,
+) -> None:
+    entry = SessionContextEntry(
+        workspace_name=_workspace_name_from_path(workspace_path),
+        workspace_path=workspace_path,
+        repository_url=repository_url,
+        branch=branch,
+        timestamp=timestamp,
+        message_index=max(0, message_index),
+        source=source,
+    )
+    key = (entry.workspace_name, entry.workspace_path, entry.repository_url, entry.branch)
+    if entries:
+        previous = entries[-1]
+        previous_key = (previous.workspace_name, previous.workspace_path, previous.repository_url, previous.branch)
+        if key == previous_key:
+            return
+    entries.append(entry)
 
 
 class _CliSessionBuilder:
@@ -644,7 +677,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
 
         # Extract workspace from session.start context or folder_trust event
         workspace_path = session_start_context.get("cwd") or session_start_context.get("gitRoot")
-        workspace_name = Path(workspace_path).name if workspace_path else None
+        workspace_name = _workspace_name_from_path(workspace_path)
         requester_username = None
         session_repository = session_start_context.get("repository")  # e.g. "owner/repo"
 
@@ -659,11 +692,29 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                     if message.startswith("Folder ") and " has been added" in message:
                         folder_path = message[7 : message.find(" has been added")]
                         workspace_path = folder_path
-                        workspace_name = Path(folder_path).name
+                        workspace_name = _workspace_name_from_path(folder_path)
 
                 elif info_type == "authentication" and not requester_username and "as user: " in message:
                     # Parse "Logged in with gh as user: Arithmomaniac"
                     requester_username = message.split("as user: ")[-1].strip()
+
+        host_type = session_start_context.get("hostType")  # "github" or "ado"
+        repository_url = None
+        if session_repository and host_type != "ado":
+            repository_url = _normalize_git_url(f"https://github.com/{session_repository}")
+        if not repository_url and host_type != "ado":
+            repository_url = detect_repository_url(workspace_path)
+
+        context_entries: list[SessionContextEntry] = []
+        _append_context_entry(
+            context_entries,
+            workspace_path=workspace_path,
+            repository_url=repository_url,
+            branch=session_start_context.get("branch"),
+            timestamp=created_at,
+            message_index=0,
+            source="initial",
+        )
 
         # Build tool execution map: toolCallId -> (start_data, complete_data, user_requested)
         tool_executions: dict = {}
@@ -1170,7 +1221,17 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 cwd = event_data.get("cwd") or ""
                 branch = event_data.get("branch") or ""
                 branch_info = f" ({branch})" if branch else ""
-                builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=f"Context changed: {cwd}{branch_info}", description="context-change"))
+                changed_repository_url = detect_repository_url(cwd) if host_type != "ado" else None
+                _append_context_entry(
+                    context_entries,
+                    workspace_path=cwd or None,
+                    repository_url=changed_repository_url,
+                    branch=branch or None,
+                    timestamp=timestamp,
+                    message_index=len(builder.messages),
+                    source="context_changed",
+                )
+                builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=f"Working directory changed: {cwd}{branch_info}", description="context-change"))
 
             elif event_type == "session.remote_steerable_changed":
                 remote_steerable = event_data.get("remoteSteerable")
@@ -1380,16 +1441,6 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
         # Get updated_at from last event timestamp
         updated_at = events[-1].get("timestamp") if events else None
 
-        # Extract additional context fields from session.start
-        host_type = session_start_context.get("hostType")  # "github" or "ado"
-
-        # Detect repository URL from session.start context or workspace path
-        repository_url = None
-        if session_repository and host_type != "ado":
-            repository_url = f"https://github.com/{session_repository}"
-        if not repository_url and host_type != "ado":
-            repository_url = detect_repository_url(workspace_path)
-
         # Determine session title: prefer session.title_changed event, then workspace.yaml, then first intent
         custom_title = None
         if session_title_from_event:
@@ -1425,6 +1476,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
             type="cli",
             repository_url=repository_url,
             root_agent_intervals=root_agent_intervals,
+            context_entries=context_entries,
         )
         session.parser_version = PARSER_VERSION
         return session

--- a/src/copilot_session_tools/scanner/models.py
+++ b/src/copilot_session_tools/scanner/models.py
@@ -137,6 +137,19 @@ class RootAgentInterval:
 
 
 @dataclass
+class SessionContextEntry:
+    """Represents the workspace/repository context active during part of a session."""
+
+    workspace_name: str | None = None
+    workspace_path: str | None = None
+    repository_url: str | None = None
+    branch: str | None = None
+    timestamp: str | None = None
+    message_index: int = 0
+    source: str = "initial"
+
+
+@dataclass
 class ChatSession:
     """Represents a Copilot chat session.
 
@@ -161,6 +174,32 @@ class ChatSession:
     parser_version: int = 1
     source_format: str | None = None  # 'cli', 'json', 'jsonl', 'vscdb'
     root_agent_intervals: list[RootAgentInterval] = field(default_factory=list)
+    context_entries: list[SessionContextEntry] = field(default_factory=list)
+
+    def effective_context_entries(self) -> list[SessionContextEntry]:
+        """Return context entries, falling back to the legacy scalar metadata."""
+        entries = list(self.context_entries)
+        if not entries and (self.workspace_name or self.workspace_path or self.repository_url):
+            entries.append(
+                SessionContextEntry(
+                    workspace_name=self.workspace_name,
+                    workspace_path=self.workspace_path,
+                    repository_url=self.repository_url,
+                    message_index=0,
+                    source="initial",
+                )
+            )
+
+        deduped: list[SessionContextEntry] = []
+        for entry in entries:
+            key = (entry.workspace_name, entry.workspace_path, entry.repository_url, entry.branch)
+            if deduped:
+                previous = deduped[-1]
+                previous_key = (previous.workspace_name, previous.workspace_path, previous.repository_url, previous.branch)
+                if key == previous_key:
+                    continue
+            deduped.append(entry)
+        return deduped
 
 
 @dataclass

--- a/src/copilot_session_tools/web/templates/index.html
+++ b/src/copilot_session_tools/web/templates/index.html
@@ -668,6 +668,12 @@ footer a {
     margin-left: 4px;
 }
 
+.snippet-context {
+    color: var(--text-secondary);
+    font-size: 0.8em;
+    margin-top: 2px;
+}
+
 .refresh-actions {
     display: flex;
     gap: 10px;
@@ -1118,6 +1124,17 @@ footer a {
                             {{ snippet.text | safe }}
                             <span class="snippet-link">#{{ snippet.message_anchor }}</span>
                         </a>
+                        {% if snippet.active_context and (
+                            (snippet.active_context.workspace_name or '') != (session.workspace_name or '') or
+                            (snippet.active_context.workspace_path or '') != (session.workspace_path or '') or
+                            (snippet.active_context.repository_url or '') != (session.repository_url or '')
+                        ) %}
+                        <div class="snippet-context">
+                            Context:
+                            {% if snippet.active_context.workspace_name %}{{ snippet.active_context.workspace_name }}{% endif %}
+                            {% if snippet.active_context.repository_url %} · {{ snippet.active_context.repository_url }}{% endif %}
+                        </div>
+                        {% endif %}
                     </div>
                     {% endfor %}
                 </div>

--- a/src/copilot_session_tools/web/templates/session.html
+++ b/src/copilot_session_tools/web/templates/session.html
@@ -2871,6 +2871,9 @@ input:checked + .toggle-switch::after {
             {% if session.workspace_path %}
             <span>📁 {{ session.workspace_path | urldecode }}</span>
             {% endif %}
+            {%- if session.repository_url %}
+            <span>Repository: {{ session.repository_url }}</span>
+            {%- endif %}
             {% if session.created_at %}
             <span>Created: {{ session.created_at | format_timestamp }}</span>
             {% endif %}
@@ -2920,6 +2923,8 @@ input:checked + .toggle-switch::after {
                             </details>
                             {% elif block.description == 'fork' %}
                             <span class="status-badge fork">{{ block.content | markdown | safe }}</span>
+                            {% elif block.description == 'context-change' %}
+                            <span class="status-badge model-change context-change">{{ block.content }}</span>
                             {% else %}
                             <span class="status-badge {{ block.description or '' }}">{{ block.content }}</span>
                             {% endif %}

--- a/src/copilot_session_tools/web/webapp.py
+++ b/src/copilot_session_tools/web/webapp.py
@@ -149,7 +149,15 @@ def create_app(
         if query:
             # Use FTS search with sort option
             # The db.search() returns results in the correct order based on sort_by
-            search_results = db.search(query, limit=100, sort_by=sort_by, search_content_set=search_content_set)
+            workspace_query = " ".join(f'workspace:"{workspace.replace(chr(34), chr(34) + chr(34))}"' for workspace in selected_workspaces)
+            search_query = f"{query} {workspace_query}".strip()
+            search_results = db.search(
+                search_query,
+                limit=100,
+                sort_by=sort_by,
+                search_content_set=search_content_set,
+                repository=selected_repositories or None,
+            )
 
             # Group results by session and collect snippets
             # session_ids preserves the order from search results (for relevance sorting)
@@ -167,6 +175,7 @@ def create_app(
                     snippet = {
                         "text": _create_snippet(r.get("highlighted", r.get("content", ""))),
                         "message_anchor": msg_index + 1,  # 1-based for #msg-N
+                        "active_context": r.get("active_context"),
                     }
                     search_snippets[sid].append(snippet)
 
@@ -181,11 +190,13 @@ def create_app(
 
         # Apply workspace filter if selected
         if selected_workspaces:
-            sessions = [s for s in sessions if s.get("workspace_name") in selected_workspaces]
+            selected_workspace_set = set(selected_workspaces)
+            sessions = [s for s in sessions if selected_workspace_set.intersection(set(s.get("workspace_names") or [s.get("workspace_name")]))]
 
         # Apply repository filter if selected
         if selected_repositories:
-            sessions = [s for s in sessions if s.get("repository_url") in selected_repositories]
+            selected_repository_set = set(selected_repositories)
+            sessions = [s for s in sessions if selected_repository_set.intersection(set(s.get("repository_urls") or [s.get("repository_url")]))]
 
         # Apply edition filter if selected
         if selected_editions:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from copilot_session_tools import ChatMessage, ChatSession, CommandRun, ContentBlock, Database, FileChange, ToolInvocation, parse_search_query
-from copilot_session_tools.scanner import RootAgentInterval
+from copilot_session_tools.scanner import RootAgentInterval, SessionContextEntry
 
 
 @pytest.fixture
@@ -87,6 +87,50 @@ class TestDatabase:
         assert len(retrieved.messages) == len(sample_session.messages)
         assert retrieved.messages[0].role == "user"
         assert "Python function" in retrieved.messages[0].content
+
+    def test_session_context_entries_persist_and_retrieve(self, temp_db):
+        """Test workspace/repository context history persists with sessions."""
+        session = ChatSession(
+            session_id="context-session",
+            workspace_name="project-one",
+            workspace_path="/work/project-one",
+            repository_url="github.com/owner/one",
+            messages=[
+                ChatMessage(role="user", content="Initial repo question"),
+                ChatMessage(role="assistant", content="Switching context"),
+                ChatMessage(role="user", content="Later repo question"),
+            ],
+            context_entries=[
+                SessionContextEntry(
+                    workspace_name="project-one",
+                    workspace_path="/work/project-one",
+                    repository_url="github.com/owner/one",
+                    message_index=0,
+                ),
+                SessionContextEntry(
+                    workspace_name="project-two",
+                    workspace_path="/work/project-two",
+                    repository_url="github.com/owner/two",
+                    branch="main",
+                    message_index=2,
+                    source="context_changed",
+                ),
+            ],
+        )
+
+        temp_db.add_session(session)
+
+        retrieved = temp_db.get_session("context-session")
+        assert retrieved is not None
+        contexts = retrieved.effective_context_entries()
+        assert [c.workspace_name for c in contexts] == ["project-one", "project-two"]
+        assert contexts[1].repository_url == "github.com/owner/two"
+        assert contexts[1].message_index == 2
+
+        listed = temp_db.list_sessions(workspace_name="project-two")
+        assert [s["session_id"] for s in listed] == ["context-session"]
+        assert listed[0]["workspace_names"] == ["project-one", "project-two"]
+        assert listed[0]["repository_urls"] == ["github.com/owner/one", "github.com/owner/two"]
 
     def test_root_agent_intervals_persist_and_retrieve(self, temp_db):
         """Test root custom-agent intervals persist and hydrate with sessions."""
@@ -726,9 +770,10 @@ class TestParseSearchQuery:
             # Case insensitive field names
             ("Role:user WORKSPACE:test", "", "user", "test", None, None),
             ("EDITION:CLI", "", None, None, None, "cli"),
-            # Duplicate field values - last one wins
+            # Duplicate scalar field values - last one wins
             ("role:user role:assistant python", "python", "assistant", None, None, None),
-            ("workspace:first workspace:second", "", None, "second", None, None),
+            # Repeated workspace filters are preserved as alternatives; workspace keeps the first value for compatibility
+            ("workspace:first workspace:second", "", None, "first", None, None),
             # FTS5 special character escaping - dashes
             ("test-driven", '"test-driven"', None, None, None, None),
             ("e-commerce m-commerce", '"e-commerce" "m-commerce"', None, None, None, None),
@@ -753,6 +798,14 @@ class TestParseSearchQuery:
         assert result.workspace == expected_workspace
         assert result.title == expected_title
         assert result.edition == expected_edition
+
+    def test_parse_search_query_preserves_repeated_context_filters(self):
+        result = parse_search_query("workspace:first workspace:second repo:one repository:two")
+
+        assert result.workspace == "first"
+        assert result.workspaces == ["first", "second"]
+        assert result.repository == "one"
+        assert result.repositories == ["one", "two"]
 
 
 @pytest.fixture
@@ -1108,6 +1161,76 @@ class TestRepositoryUrlSupport:
         # Search with repository: prefix
         results = temp_db.search("repository:other Hello")
         assert len(results) == 1
+
+    def test_search_matches_later_context_and_reports_active_context(self, temp_db):
+        """Search filters match any session context and report context active at the hit."""
+        session = ChatSession(
+            session_id="multi-context-search",
+            workspace_name="project-one",
+            workspace_path="/work/project-one",
+            repository_url="github.com/owner/one",
+            messages=[
+                ChatMessage(role="user", content="Alpha only", timestamp="2025-01-01T00:00:00Z"),
+                ChatMessage(role="assistant", content="Changed context", timestamp="2025-01-01T00:01:00Z"),
+                ChatMessage(role="user", content="Need beta feature", timestamp="2025-01-01T00:02:00Z"),
+            ],
+            context_entries=[
+                SessionContextEntry(
+                    workspace_name="project-one",
+                    workspace_path="/work/project-one",
+                    repository_url="github.com/owner/one",
+                    message_index=0,
+                ),
+                SessionContextEntry(
+                    workspace_name="project-two",
+                    workspace_path="/work/project-two",
+                    repository_url="github.com/owner/two",
+                    message_index=2,
+                    source="context_changed",
+                ),
+            ],
+        )
+        temp_db.add_session(session)
+
+        results = temp_db.search("repo:two beta")
+
+        assert len(results) == 1
+        assert results[0]["session_id"] == "multi-context-search"
+        assert results[0]["active_context"]["workspace_name"] == "project-two"
+        assert results[0]["repository_url"] == "github.com/owner/two"
+
+        assert temp_db.search("repo:two Alpha") == []
+        assert temp_db.search("workspace:project-two Alpha") == []
+
+    def test_repeated_repository_prefixes_are_or_filters(self, temp_db):
+        session1 = ChatSession(
+            session_id="or-repo-1",
+            workspace_name="project1",
+            workspace_path="/path/to/project1",
+            messages=[ChatMessage(role="user", content="Repeated filter")],
+            repository_url="github.com/owner/repo1",
+        )
+        session2 = ChatSession(
+            session_id="or-repo-2",
+            workspace_name="project2",
+            workspace_path="/path/to/project2",
+            messages=[ChatMessage(role="user", content="Repeated filter")],
+            repository_url="github.com/owner/repo2",
+        )
+        session3 = ChatSession(
+            session_id="or-repo-3",
+            workspace_name="project3",
+            workspace_path="/path/to/project3",
+            messages=[ChatMessage(role="user", content="Repeated filter")],
+            repository_url="github.com/owner/repo3",
+        )
+        temp_db.add_session(session1)
+        temp_db.add_session(session2)
+        temp_db.add_session(session3)
+
+        results = temp_db.search("repo:repo1 repo:repo2 Repeated")
+
+        assert {r["session_id"] for r in results} == {"or-repo-1", "or-repo-2"}
 
 
 class TestDateFiltering:
@@ -2363,6 +2486,42 @@ class TestSchemaV6:
         msg_cols = {row[1] for row in conn.execute("PRAGMA table_info(cst_messages)")}
         assert "parent_message_id" in msg_cols
         assert "child_index" in msg_cols
+
+        conn.close()
+
+
+class TestChronicleSchemaVersion:
+    """Tests for Chronicle schema compatibility warnings."""
+
+    def test_known_chronicle_schema_version_does_not_warn(self):
+        """Chronicle schema v4 is currently supported by CST's read queries."""
+        import warnings
+
+        from copilot_session_tools.db_storage import CHRONICLE_SCHEMA_VERSION, check_builtin_schema_version
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("ATTACH DATABASE ':memory:' AS chronicle")
+        conn.execute("CREATE TABLE chronicle.schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO chronicle.schema_version VALUES (?)", (CHRONICLE_SCHEMA_VERSION,))
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            check_builtin_schema_version(conn)
+
+        assert recorded == []
+        conn.close()
+
+    def test_future_chronicle_schema_version_warns(self):
+        """A future Chronicle schema still warns so parser compatibility is revisited."""
+        from copilot_session_tools.db_storage import CHRONICLE_SCHEMA_VERSION, check_builtin_schema_version
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("ATTACH DATABASE ':memory:' AS chronicle")
+        conn.execute("CREATE TABLE chronicle.schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO chronicle.schema_version VALUES (?)", (CHRONICLE_SCHEMA_VERSION + 1,))
+
+        with pytest.warns(UserWarning, match=f"newer than expected \\({CHRONICLE_SCHEMA_VERSION}\\)"):
+            check_builtin_schema_version(conn)
 
         conn.close()
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1655,7 +1655,7 @@ class TestCLINewEventHandlers:
         )
         blocks = self._find_status_blocks(session, "context-change")
         assert len(blocks) == 1
-        assert blocks[0].content == "Context changed: /home/user/project (feature/x)"
+        assert blocks[0].content == "Working directory changed: /home/user/project (feature/x)"
 
     def test_session_context_changed_no_branch(self, tmp_path):
         session = self._parse(
@@ -1664,7 +1664,7 @@ class TestCLINewEventHandlers:
         )
         blocks = self._find_status_blocks(session, "context-change")
         assert len(blocks) == 1
-        assert blocks[0].content == "Context changed: /home/user/project"
+        assert blocks[0].content == "Working directory changed: /home/user/project"
 
     # --- session.plan_changed ---
 
@@ -3138,7 +3138,8 @@ class TestCLIv105EventHandlers:
             },
         )
         assert session is not None
-        assert session.repository_url == "https://github.com/owner/repo"
+        assert session.repository_url == "github.com/owner/repo"
+        assert session.context_entries[0].repository_url == "github.com/owner/repo"
 
     def test_session_start_host_type_ado(self, tmp_path):
         """session.start with hostType=ado should NOT generate any repository URL."""
@@ -3165,7 +3166,38 @@ class TestCLIv105EventHandlers:
             },
         )
         assert session is not None
-        assert session.repository_url == "https://github.com/owner/repo"
+        assert session.repository_url == "github.com/owner/repo"
+
+    def test_session_start_repository_matches_detected_context_format(self, tmp_path):
+        """Initial GitHub metadata uses the same normalized form as detected context changes."""
+        import subprocess
+
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        subprocess.run(["git", "init"], cwd=workspace, capture_output=True, check=True)  # noqa: S607
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/owner/repo.git"],  # noqa: S607
+            cwd=workspace,
+            capture_output=True,
+            check=True,
+        )
+
+        session = self._parse(
+            tmp_path,
+            {"type": "user.message", "data": {"content": "Hello"}},
+            {"type": "session.context_changed", "data": {"cwd": str(workspace), "branch": "main"}},
+            {"type": "assistant.message", "data": {"content": "Hi"}},
+            start_data={
+                "context": {"cwd": "/home/user/project", "hostType": "github", "repository": "owner/repo"},
+            },
+        )
+
+        assert session is not None
+        assert session.repository_url == "github.com/owner/repo"
+        assert [entry.repository_url for entry in session.context_entries] == [
+            "github.com/owner/repo",
+            "github.com/owner/repo",
+        ]
 
     # ---- T5: intentionSummary and toolTitle on toolRequests ----
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from copilot_session_tools import ChatMessage, ChatSession, ContentBlock, Database, RootAgentInterval
+from copilot_session_tools import ChatMessage, ChatSession, ContentBlock, Database, RootAgentInterval, SessionContextEntry
 from copilot_session_tools.utils import (
     extract_filename as _extract_filename,
 )
@@ -342,6 +342,88 @@ class TestWebappRoutes:
         assert response.status_code == 200
         assert b"Entered smart-merge" in response.data
         assert b"Back to default" in response.data
+
+    def test_session_uses_inline_context_change_message(self, temp_db):
+        """Context changes render as inline status messages, not a session summary."""
+        db = Database(temp_db)
+        session = ChatSession(
+            session_id="context-inline-session",
+            workspace_name="project-one",
+            workspace_path="/workspace/one",
+            repository_url="github.com/example/one",
+            messages=[
+                ChatMessage(role="user", content="start"),
+                ChatMessage(
+                    role="assistant",
+                    content="Working directory changed: /workspace/two (feature/x)",
+                    content_blocks=[
+                        ContentBlock(
+                            kind="status",
+                            content="Working directory changed: /workspace/two (feature/x)",
+                            description="context-change",
+                        )
+                    ],
+                ),
+            ],
+            context_entries=[
+                SessionContextEntry(message_index=0, workspace_name="project-one", workspace_path="/workspace/one", repository_url="github.com/example/one", source="initial"),
+                SessionContextEntry(
+                    message_index=1,
+                    workspace_name="project-two",
+                    workspace_path="/workspace/two",
+                    repository_url="github.com/example/two",
+                    branch="feature/x",
+                    source="context_changed",
+                ),
+            ],
+        )
+        db.add_session(session)
+
+        app = create_app(temp_db, title="Test Archive", storage_paths=[])
+        app.config["TESTING"] = True
+        response = app.test_client().get("/session/context-inline-session")
+
+        assert response.status_code == 200
+        html = response.data.decode("utf-8")
+        assert "Context changed 1 time" not in html
+        assert "Working directory changed: /workspace/two (feature/x)" in html
+        assert "status-badge model-change context-change" in html
+
+    def test_search_snippet_context_only_when_different_from_root(self, temp_db):
+        """Search snippets omit root context but show later active context."""
+        db = Database(temp_db)
+        session = ChatSession(
+            session_id="context-snippet-session",
+            workspace_name="project-one",
+            workspace_path="/workspace/one",
+            repository_url="github.com/example/one",
+            messages=[
+                ChatMessage(role="user", content="alpha in the first project"),
+                ChatMessage(role="assistant", content="beta in the second project"),
+            ],
+            context_entries=[
+                SessionContextEntry(message_index=0, workspace_name="project-one", workspace_path="/workspace/one", repository_url="github.com/example/one", source="initial"),
+                SessionContextEntry(
+                    message_index=1, workspace_name="project-two", workspace_path="/workspace/two", repository_url="github.com/example/two", source="context_changed"
+                ),
+            ],
+        )
+        db.add_session(session)
+
+        app = create_app(temp_db, title="Test Archive", storage_paths=[])
+        app.config["TESTING"] = True
+        client = app.test_client()
+
+        root_response = client.get("/?q=alpha")
+        assert root_response.status_code == 200
+        assert '<div class="snippet-context">' not in root_response.data.decode("utf-8")
+
+        changed_response = client.get("/?q=beta")
+        assert changed_response.status_code == 200
+        changed_html = changed_response.data.decode("utf-8")
+        assert '<div class="snippet-context">' in changed_html
+        assert "project-two" in changed_html
+        assert "github.com/example/two" in changed_html
 
     def test_session_not_found(self, client):
         """Test 404 for non-existent session."""

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Scanner / model | Track working-directory and repository context changes over time via session context entries. |
| Database | Persist context history in a normalized `cst_session_contexts` table and migrate schema to v10. |
| Search / filters | Allow repeated `repo:` and `workspace:` filters as OR alternatives, and match filters against the active context at each hit. |
| Web / export | Render working-directory changes inline and only show search-hit context when it differs from the session root context. |
| Release | Bump package metadata and changelog to `0.15.0`; recognize Chronicle schema v4 as compatible. |

## Review

- Tri-review completed with Opus 4.7 and GPT-5.5; MAI run was cancelled per user request.
- Opus found no issues.
- GPT found a repository URL normalization mismatch; fixed by normalizing initial CLI GitHub metadata to match detected Git remote format and adding regression coverage.

## Validation

- `uv run pytest tests\ --ignore=tests\test_webapp_e2e.py -v`
- `uv run ruff check .`
- `uv run ty check`
- Pre-push hook: Ruff lint + Ruff format

Note: an e2e-inclusive `uv run pytest` progressed through 11 webapp e2e tests but was stopped due to the suite running very slowly; repo-standard validation excludes `tests/test_webapp_e2e.py`.