### PR TITLE
Add targeted session rescan CLI option

### DIFF
--- a/.claude/skills/search-copilot-chats/SKILL.md
+++ b/.claude/skills/search-copilot-chats/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: search-copilot-chats
-description: Search across archived Copilot chat sessions (VS Code + CLI) using the copilot-session-tools CLI. Use when the user says "search my chats", "find in chat history", "what did we discuss about X", "look up past sessions", "scan chats", "session history", "recent session where", "earlier conversation", "previous session", "that session where", or references a session-state path or session GUID. Also covers exporting sessions as markdown or HTML and launching the web viewer.
+description: Search archived Copilot chat sessions using Chronicle/session_store SQL as the first hint layer, then copilot-session-tools for targeted lookup/export. Use when the user says "search my chats", "find in chat history", "what did we discuss about X", "look up past sessions", "scan chats", "session history", "recent session where", "earlier conversation", "previous session", "that session where", or references a session-state path or session GUID. Also covers exporting narrowed sessions as markdown/HTML and launching the web viewer.
 ---
 
 # Search Copilot Chats
 
-Search, browse, and export archived GitHub Copilot chat sessions from VS Code (Stable & Insiders) and the Copilot CLI. Uses the **copilot-session-tools** CLI backed by a local SQLite database with FTS5 full-text search. Requires Copilot CLI v0.0.412+ (`uv tool install copilot-session-tools[all]` if not on PATH).
+Search, browse, and export archived GitHub Copilot chat sessions from VS Code (Stable & Insiders) and the Copilot CLI. Use **Chronicle/session_store SQL** as the first hint/index layer when available, then use the **copilot-session-tools** CLI for targeted lookup, export, and web viewing. The CLI is backed by a local SQLite database with FTS5 full-text search. Requires Copilot CLI v0.0.412+ (`uv tool install copilot-session-tools[all]` if not on PATH).
 
 **Do not memorize flags.** Run `copilot-session-tools <command> --help` for flags and examples. This skill only documents **domain knowledge that `--help` cannot teach**.
 
@@ -17,9 +17,20 @@ Search, browse, and export archived GitHub Copilot chat sessions from VS Code (S
 - User wants to find prior decisions, code patterns, or troubleshooting steps from past sessions
 - User asks to export a session as markdown, HTML, or JSON
 
-## Favor CLI over Python
+## Default workflow: Chronicle first, CLI second
 
-**Always prefer CLI execution** over writing Python scripts. The CLI handles all common workflows. Only drop into Python/SQL when you need a custom join, aggregation, or programmatic processing the CLI doesn't support.
+For timeline, "find the session where...", prior-discussion, and session-reference tasks, **start with Chronicle/session_store SQL**. Treat it as the cheap hint/index layer that identifies likely sessions before running heavier CLI searches or exports.
+
+1. Query `session_store` first using the built-in SQL tool when available. Search `sessions`, `turns`, `checkpoints`, `session_files`, `session_refs`, and `search_index` for candidate session IDs, dates, branches, files, or PR/issue refs.
+2. Use query expansion yourself: search several related keywords in SQL (`bug OR fix OR error`, `auth OR login OR token`, etc.) rather than firing many broad CLI searches.
+3. Run `copilot-session-tools search` only after SQL hints identify likely terms, workspaces, date ranges, or session IDs. Keep it targeted.
+4. Export full markdown only after narrowing to a specific candidate session ID.
+
+**Do not** launch broad parallel bursts of `copilot-session-tools search --json` when Chronicle/session_store can first identify candidates. Broad CLI searches are a fallback, not the default.
+
+**Ask before running expensive refresh operations**: `scan`, `--full`, or broad rescans require user confirmation unless the user explicitly asked to refresh/rescan/reindex. If you already have a specific CLI session ID and need current enriched content, prefer the targeted `--rescan-session <session-id>` option on the relevant command; this is a single-session refresh, not a broad rescan.
+
+Prefer CLI execution over writing Python scripts once candidates are known. Only drop into Python or direct SQLite when you need a custom join, aggregation, or programmatic processing the CLI doesn't support.
 
 ## Search strategy (critical — not in `--help`)
 
@@ -56,13 +67,15 @@ The FTS5 search uses **AND semantics**: every keyword in the query MUST appear i
 **Iterative search workflow:**
 
 ```
-Step 1: copilot-session-tools search "resource graph" --full --limit 20
+Step 0: Query Chronicle/session_store SQL for candidate sessions, dates, branches, or refs
+  → Found likely session IDs? Export the best candidate directly.
+Step 1: copilot-session-tools search "resource graph" --limit 20
   → Too many results? Add ONE keyword:
-Step 2: copilot-session-tools search "resource graph" auth --full --limit 20
+Step 2: copilot-session-tools search "resource graph" auth --limit 20
   → Still too many? Add a workspace filter:
-Step 3: copilot-session-tools search 'workspace:ZTS "resource graph" auth' --full --limit 10
+Step 3: copilot-session-tools search 'workspace:ZTS "resource graph" auth' --limit 10
   → No results? Back up and try different keyword:
-Step 4: copilot-session-tools search 'workspace:ZTS "resource graph" permission' --full --limit 10
+Step 4: copilot-session-tools search 'workspace:ZTS "resource graph" permission' --limit 10
 ```
 
 ## Extract session references from user input
@@ -74,9 +87,53 @@ Users reference past sessions in several ways. Recognize and extract the session
 | `C:\Users\...\session-state\{uuid}` or `~\.copilot\session-state\{uuid}` | The `{uuid}` portion |
 | `http://127.0.0.1:5000/session/{uuid}` | The `{uuid}` portion |
 | A bare GUID like `67894303-8571-...` | Use directly as session ID |
-| A short prefix like `67894303` | Search: `copilot-session-tools search "67894303"` |
+| A short prefix like `67894303` | Query `session_store.sessions` / `session_store.search_index` for matching IDs first; then targeted CLI search if needed |
 
-Then use `export-markdown --session-id` to retrieve the full session content.
+Then use `export-markdown --session-id` to retrieve the full session content only after the session ID is specific enough.
+
+## Chronicle/session_store hint queries
+
+Use these patterns with the built-in SQL tool (`database: "session_store"`) before CLI search:
+
+```sql
+-- Recent timeline / "what was I doing?"
+SELECT id, cwd, repository, branch, summary, created_at
+FROM sessions
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Prior discussion with expanded keywords
+SELECT content, session_id, source_type
+FROM search_index
+WHERE search_index MATCH 'auth OR login OR token OR JWT OR session'
+ORDER BY rank
+LIMIT 20;
+
+-- Sessions that touched or mentioned a file/path
+SELECT s.id, s.summary, sf.file_path, sf.tool_name
+FROM session_files sf
+JOIN sessions s ON s.id = sf.session_id
+WHERE sf.file_path LIKE '%auth%'
+ORDER BY sf.first_seen_at DESC
+LIMIT 20;
+
+-- Session linked to a PR/issue/commit
+SELECT s.id, s.summary, sr.ref_type, sr.ref_value, sr.created_at
+FROM session_refs sr
+JOIN sessions s ON s.id = sr.session_id
+WHERE sr.ref_value = '42'
+ORDER BY sr.created_at DESC;
+```
+
+After SQL returns candidates, use targeted CLI commands such as:
+
+```powershell
+copilot-session-tools search 'workspace:ZTS "resource graph" auth' --limit 10 --json
+copilot-session-tools export-markdown --session-id <candidate-session-id> -o .
+copilot-session-tools export-markdown --session-id <candidate-session-id> --rescan-session <candidate-session-id> -o .
+```
+
+Use `--rescan-session` when Chronicle found the target session but `cst_*` enrichment may be stale or missing. This can bootstrap a CLI session that has never been enriched by `copilot-session-tools` yet, as long as `~/.copilot/session-state/<session-id>/events.jsonl` still exists.
 
 ## Direct SQL for advanced queries
 
@@ -126,16 +183,18 @@ The tool extends `~/.copilot/copilot-session-tools.db` with `cst_*` enrichment t
 ## Workflow: "Continue where we left off"
 
 1. Extract the session GUID from the user's input (see table above)
-2. Export: `copilot-session-tools export-markdown --session-id <guid> -o .`
-3. Read the exported file and continue the work
+2. If the user provided only a prefix or indirect reference, query Chronicle/session_store to resolve the likely full session ID
+3. Export fresh content: `copilot-session-tools export-markdown --session-id <guid> --rescan-session <guid> -o .`
+4. Read the exported file and continue the work
 
 ## Workflow: "Find how we solved X before"
 
-1. Search: `copilot-session-tools search "<topic>" --full --limit 30`
-2. Identify the most relevant session from results
-3. Export: `copilot-session-tools export-markdown --session-id <guid> -o .`
+1. Query Chronicle/session_store SQL with expanded keywords to find candidate sessions
+2. Use targeted `copilot-session-tools search "<topic>" --limit 10 --json` only for the most promising candidates/terms
+3. Identify the most relevant session from results
+4. Export fresh content: `copilot-session-tools export-markdown --session-id <guid> --rescan-session <guid> -o .`
 
 ## Known issues
 
 - **Use `--json` for piped output.** The default Rich console output garbles Unicode box-drawing characters on Windows when piped. `--json` bypasses Rich entirely and is the preferred format for programmatic consumption.
-- **Missing sessions**: If a session doesn't appear after scanning, check that the source file exists and wasn't cleaned up by VS Code. Use `--full` scan to force reimport.
+- **Missing sessions**: If Chronicle identifies a CLI session but `copilot-session-tools` lacks enriched details, use `--rescan-session <session-id>` on the targeted search/export command. If a session still doesn't appear, check that the source file exists and wasn't cleaned up by VS Code. Ask before using `scan`, `--full`, or any broad rescan unless the user explicitly requested refresh/rescan.

--- a/.github/agents/scanner-refresh.agent.md
+++ b/.github/agents/scanner-refresh.agent.md
@@ -109,8 +109,7 @@ Check recent commits and PRs since `$lastScannerChange` in:
 | `github/copilot-agent-runtime` | New CLI event types, payloads, rendering behavior, changelog entries, runtime definitions |
 | `github/copilot-cli` | Session JSONL structure or public CLI changes |
 | `github/copilot-sdk` | SDK schema/data-structure changes |
-| `microsoft/vscode-copilot-chat` | Response item kinds, background/cloud session storage |
-| `microsoft/vscode` | Chat serialization, storage, locations, copy-all behavior |
+| `microsoft/vscode` | Chat serialization, response item kinds, background/cloud session storage, locations, copy-all behavior |
 
 Use available GitHub tools or `gh`/web research. Save findings to `temp_export\upstream-research.md`.
 
@@ -291,8 +290,7 @@ If full-repo Ruff output is dominated by unrelated pre-existing files, do not ch
 1. Find a real session containing the new event/response kind.
 2. Enrich and export it:
    ```powershell
-   uv run copilot-session-tools enrich <session-id>
-   uv run copilot-session-tools export-markdown --session-id <session-id> --output-dir temp_export
+   uv run copilot-session-tools export-markdown --session-id <session-id> --rescan-session <session-id> --output-dir temp_export
    ```
 3. Start the web viewer:
    ```powershell

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,14 @@
     "workbench.colorCustomizations": {
         "activityBar.background": "#84D865",
         "titleBar.activeBackground": "#98DE7E",
-        "titleBar.activeForeground": "#0D1D07"
+        "titleBar.activeForeground": "#0D1D07",
+        "titleBar.inactiveBackground": "#18340D",
+        "titleBar.inactiveForeground": "#0D1D07",
+        "statusBar.background": "#1F4411",
+        "statusBar.foreground": "#F5FCF3",
+        "statusBar.debuggingBackground": "#1F4411",
+        "statusBar.debuggingForeground": "#F5FCF3",
+        "statusBar.noFolderBackground": "#1F4411",
+        "statusBar.noFolderForeground": "#F5FCF3"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-06-05
+
+### Added
+
+- **CLI**: Added `--rescan-session <session-id>` to `search`, `export-markdown`, and `export-html` so a single CLI session can be parsed/enriched immediately before the command runs.
+- **CLI**: Targeted rescans can bootstrap a missing CST enrichment database for never-scanned sessions when explicitly requested.
+- **Agent Workflow**: Updated Copilot chat search guidance to use targeted rescans after Chronicle identifies a specific candidate session.
+
+### Fixed
+
+- **CLI**: Session-specific exports now reject mismatched `--session-id` and `--rescan-session` values instead of silently refreshing one session and exporting another.
+
 ## [0.15.0] - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.15.0"
+version = "0.15.1"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 from .content_types import (
     CONTENT_TYPES,

--- a/src/copilot_session_tools/cli.py
+++ b/src/copilot_session_tools/cli.py
@@ -71,6 +71,15 @@ def _ensure_db_exists(db: Path) -> None:
         raise typer.Exit(code=2)
 
 
+def _make_database_for_command(db: Path, *, allow_create: bool = False) -> "Database":
+    """Create a Database for a command, optionally bootstrapping the DB file."""
+    if allow_create:
+        db.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        _ensure_db_exists(db)
+    return _make_database(db)
+
+
 app = typer.Typer(
     name="copilot-session-tools",
     help="Create a searchable archive of VS Code GitHub Copilot chats.",
@@ -86,6 +95,29 @@ _chronicle_db: Path | None = None
 def _make_database(db: str | Path) -> "Database":
     """Create a Database with the current global settings."""
     return Database(db, unenriched_only=_unenriched_only, chronicle_db_path=_chronicle_db)
+
+
+def _rescan_session_before_command(
+    database: "Database",
+    rescan_session_id: str | None,
+    *,
+    expected_session_id: str | None = None,
+) -> None:
+    """Run a targeted CLI session enrichment before a command proceeds."""
+    if rescan_session_id is None:
+        return
+
+    if expected_session_id is not None and rescan_session_id != expected_session_id:
+        typer.echo(
+            f"Error: --rescan-session ({rescan_session_id}) must match --session-id ({expected_session_id}).",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    error = enrich_single_session(database, rescan_session_id)
+    if error:
+        typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(1)
 
 
 def version_callback(value: bool):
@@ -413,6 +445,13 @@ def search(
             help="Output results as JSON for programmatic consumption.",
         ),
     ] = False,
+    rescan_session: Annotated[
+        str | None,
+        typer.Option(
+            "--rescan-session",
+            help="Parse and enrich one CLI session by ID before searching.",
+        ),
+    ] = None,
 ):
     """Search chat messages in the database.
 
@@ -434,6 +473,7 @@ def search(
       copilot-session-tools search "start_date:2024-01-01 end_date:2024-06-30"
       copilot-session-tools search '"exact phrase"'
       copilot-session-tools search "python function" --json
+      copilot-session-tools search "tool result" --rescan-session a1b2c3d4-...
 
     Use --role to filter by user requests or assistant responses.
     Use --title to filter by session/workspace name.
@@ -443,8 +483,8 @@ def search(
     Use --full to show complete content instead of truncated snippets.
     Use --sort to sort by relevance (default) or date.
     Use --json to output results as JSON for programmatic consumption.
+    Use --rescan-session to refresh one CLI session before searching.
     """
-    _ensure_db_exists(db)
     if role and role not in ("user", "assistant"):
         console.print("[red]Error: role must be 'user' or 'assistant'[/red]")
         console.print('[dim]  copilot-session-tools search "query" --role user[/dim]')
@@ -457,7 +497,8 @@ def search(
 
     search_content_set = resolve_search_content_set(include, exclude)
 
-    database = _make_database(db)
+    database = _make_database_for_command(db, allow_create=rescan_session is not None)
+    _rescan_session_before_command(database, rescan_session)
     results = database.search(
         query,
         limit=limit,
@@ -646,6 +687,13 @@ def export_markdown(
             help="Export only a specific session by ID.",
         ),
     ] = None,
+    rescan_session: Annotated[
+        str | None,
+        typer.Option(
+            "--rescan-session",
+            help="Parse and enrich one CLI session by ID before exporting.",
+        ),
+    ] = None,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -687,10 +735,11 @@ def export_markdown(
     Examples:
       copilot-session-tools export-markdown -o ./exports
       copilot-session-tools export-markdown --session-id a1b2c3d4-... -o .
+      copilot-session-tools export-markdown --session-id a1b2c3d4-... --rescan-session a1b2c3d4-... -o .
       copilot-session-tools export-markdown --exclude tool-results,thinking
     """
-    _ensure_db_exists(db)
-    database = _make_database(db)
+    database = _make_database_for_command(db, allow_create=rescan_session is not None)
+    _rescan_session_before_command(database, rescan_session, expected_session_id=session_id)
 
     content_set = resolve_content_set(include, exclude)
 
@@ -750,6 +799,13 @@ def export_html(
             help="Export only a specific session by ID.",
         ),
     ] = None,
+    rescan_session: Annotated[
+        str | None,
+        typer.Option(
+            "--rescan-session",
+            help="Parse and enrich one CLI session by ID before exporting.",
+        ),
+    ] = None,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -789,10 +845,11 @@ def export_html(
     Examples:
       copilot-session-tools export-html -o ./exports
       copilot-session-tools export-html --session-id a1b2c3d4-... -o .
+      copilot-session-tools export-html --session-id a1b2c3d4-... --rescan-session a1b2c3d4-... -o .
       copilot-session-tools export-html --exclude tool-results,thinking
     """
-    _ensure_db_exists(db)
-    database = _make_database(db)
+    database = _make_database_for_command(db, allow_create=rescan_session is not None)
+    _rescan_session_before_command(database, rescan_session, expected_session_id=session_id)
 
     content_set = resolve_content_set(include, exclude)
 

--- a/src/copilot_session_tools/cli.py
+++ b/src/copilot_session_tools/cli.py
@@ -31,6 +31,7 @@ from copilot_session_tools.content_types import (
 from copilot_session_tools.refresh import (
     DEFAULT_PARSE_WORKERS,
     enrich_single_session,
+    parse_single_cli_session,
     run_enrichment,
     run_refresh,
 )
@@ -97,15 +98,14 @@ def _make_database(db: str | Path) -> "Database":
     return Database(db, unenriched_only=_unenriched_only, chronicle_db_path=_chronicle_db)
 
 
-def _rescan_session_before_command(
-    database: "Database",
+def _validate_rescan_session(
     rescan_session_id: str | None,
     *,
     expected_session_id: str | None = None,
-) -> None:
-    """Run a targeted CLI session enrichment before a command proceeds."""
+) -> ChatSession | None:
+    """Validate and parse a targeted CLI session before DB creation."""
     if rescan_session_id is None:
-        return
+        return None
 
     if expected_session_id is not None and rescan_session_id != expected_session_id:
         typer.echo(
@@ -114,10 +114,26 @@ def _rescan_session_before_command(
         )
         raise typer.Exit(1)
 
-    error = enrich_single_session(database, rescan_session_id)
-    if error:
-        typer.echo(f"Error: {error}", err=True)
+    parsed = parse_single_cli_session(rescan_session_id)
+    if isinstance(parsed, str):
+        typer.echo(f"Error: {parsed}", err=True)
         raise typer.Exit(1)
+
+    return parsed
+
+
+def _prepare_database_for_command(
+    db: Path,
+    *,
+    rescan_session_id: str | None = None,
+    expected_session_id: str | None = None,
+) -> "Database":
+    """Create a Database and apply a targeted rescan when requested."""
+    parsed_rescan = _validate_rescan_session(rescan_session_id, expected_session_id=expected_session_id)
+    database = _make_database_for_command(db, allow_create=parsed_rescan is not None)
+    if parsed_rescan is not None:
+        database.enrich_session(parsed_rescan)
+    return database
 
 
 def version_callback(value: bool):
@@ -497,8 +513,7 @@ def search(
 
     search_content_set = resolve_search_content_set(include, exclude)
 
-    database = _make_database_for_command(db, allow_create=rescan_session is not None)
-    _rescan_session_before_command(database, rescan_session)
+    database = _prepare_database_for_command(db, rescan_session_id=rescan_session)
     results = database.search(
         query,
         limit=limit,
@@ -738,8 +753,7 @@ def export_markdown(
       copilot-session-tools export-markdown --session-id a1b2c3d4-... --rescan-session a1b2c3d4-... -o .
       copilot-session-tools export-markdown --exclude tool-results,thinking
     """
-    database = _make_database_for_command(db, allow_create=rescan_session is not None)
-    _rescan_session_before_command(database, rescan_session, expected_session_id=session_id)
+    database = _prepare_database_for_command(db, rescan_session_id=rescan_session, expected_session_id=session_id)
 
     content_set = resolve_content_set(include, exclude)
 
@@ -848,8 +862,7 @@ def export_html(
       copilot-session-tools export-html --session-id a1b2c3d4-... --rescan-session a1b2c3d4-... -o .
       copilot-session-tools export-html --exclude tool-results,thinking
     """
-    database = _make_database_for_command(db, allow_create=rescan_session is not None)
-    _rescan_session_before_command(database, rescan_session, expected_session_id=session_id)
+    database = _prepare_database_for_command(db, rescan_session_id=rescan_session, expected_session_id=session_id)
 
     content_set = resolve_content_set(include, exclude)
 

--- a/src/copilot_session_tools/refresh.py
+++ b/src/copilot_session_tools/refresh.py
@@ -435,6 +435,23 @@ def enrich_single_session(
     Returns:
         ``None`` on success, or an error message string on failure.
     """
+    parsed = parse_single_cli_session(session_id, validate=validate)
+    if isinstance(parsed, str):
+        return parsed
+
+    database.enrich_session(parsed)
+    return None
+
+
+def parse_single_cli_session(
+    session_id: str,
+    *,
+    validate: bool = True,
+) -> ChatSession | str:
+    """Parse a CLI session's ``events.jsonl`` without writing to the database.
+
+    Returns a :class:`ChatSession` on success, or an error message string on failure.
+    """
     if validate and not _SESSION_ID_RE.match(session_id):
         return f"Invalid session ID format: {session_id}"
 
@@ -446,5 +463,4 @@ def enrich_single_session(
     if parsed is None:
         return f"Failed to parse events.jsonl for session {session_id}"
 
-    database.enrich_session(parsed)
-    return None
+    return parsed

--- a/src/copilot_session_tools/scanner/__init__.py
+++ b/src/copilot_session_tools/scanner/__init__.py
@@ -2,7 +2,7 @@
 
 Data structures are informed by:
 - Arbuzov/copilot-chat-history (https://github.com/Arbuzov/copilot-chat-history)
-- microsoft/vscode-copilot-chat (https://github.com/microsoft/vscode-copilot-chat)
+- microsoft/vscode (https://github.com/microsoft/vscode)
 """
 
 PARSER_VERSION = 4

--- a/src/copilot_session_tools/scanner/cli.py
+++ b/src/copilot_session_tools/scanner/cli.py
@@ -591,8 +591,8 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
     - tool.user_requested: User-requested tool executions
     - abort: Session/turn abort events
 
-    This function renders CLI sessions similarly to how vscode-copilot-chat renders
-    background chats:
+    This function renders CLI sessions similarly to how VS Code renders background
+    chats:
     - Consecutive assistant messages are combined into one
     - Tool calls are displayed inline within the assistant message content
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,89 @@ class TestCLI:
         assert result.exit_code == 1
         assert "not found" in result.output
 
+    def test_export_markdown_rescan_session_bootstraps_missing_db(self, runner, tmp_path):
+        """--rescan-session can create the CST DB and export a never-scanned session."""
+        db_path = tmp_path / "missing.db"
+        output_dir = tmp_path / "markdown_output"
+        session_id = "rescanned-session"
+
+        def fake_enrich(database, requested_session_id):
+            database.enrich_session(
+                ChatSession(
+                    session_id=requested_session_id,
+                    workspace_name="rescanned-workspace",
+                    workspace_path="/tmp/rescanned",
+                    messages=[ChatMessage(role="user", content="Fresh bootstrap content")],
+                    vscode_edition="cli",
+                    type="cli",
+                )
+            )
+            return None
+
+        with patch("copilot_session_tools.cli.enrich_single_session", side_effect=fake_enrich) as mock_enrich:
+            result = runner.invoke(
+                app,
+                [
+                    "export-markdown",
+                    "--db",
+                    str(db_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--session-id",
+                    session_id,
+                    "--rescan-session",
+                    session_id,
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_enrich.assert_called_once()
+        assert db_path.exists()
+        md_files = list(output_dir.glob("*.md"))
+        assert len(md_files) == 1
+        assert "Fresh bootstrap content" in md_files[0].read_text(encoding="utf-8")
+
+    def test_export_markdown_rescan_session_must_match_session_id(self, runner, temp_db_with_data, tmp_path):
+        """Session-scoped exports reject mismatched --rescan-session values."""
+        result = runner.invoke(
+            app,
+            [
+                "export-markdown",
+                "--db",
+                str(temp_db_with_data),
+                "--output-dir",
+                str(tmp_path / "markdown_output"),
+                "--session-id",
+                "cli-test-session",
+                "--rescan-session",
+                "other-session",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "must match --session-id" in result.output
+
+    def test_export_markdown_rescan_session_surfaces_enrichment_error(self, runner, temp_db_with_data, tmp_path):
+        """Targeted rescan failures stop the command before export."""
+        with patch("copilot_session_tools.cli.enrich_single_session", return_value="events.jsonl not found for session missing-session"):
+            result = runner.invoke(
+                app,
+                [
+                    "export-markdown",
+                    "--db",
+                    str(temp_db_with_data),
+                    "--output-dir",
+                    str(tmp_path / "markdown_output"),
+                    "--session-id",
+                    "missing-session",
+                    "--rescan-session",
+                    "missing-session",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "events.jsonl not found" in result.output
+
     def test_export_html_command(self, runner, temp_db_with_data, tmp_path):
         """Test export-html command exports sessions to HTML files."""
         output_dir = tmp_path / "html_output"
@@ -344,6 +427,44 @@ class TestCLI:
         assert "<!DOCTYPE html>" in content
         assert "message-content" in content
         assert "--container-max-width: none" in content
+
+    def test_search_rescan_session_bootstraps_missing_db_with_json_output(self, runner, tmp_path):
+        """--rescan-session runs before search without polluting --json stdout."""
+        db_path = tmp_path / "missing.db"
+        session_id = "search-rescanned-session"
+
+        def fake_enrich(database, requested_session_id):
+            database.enrich_session(
+                ChatSession(
+                    session_id=requested_session_id,
+                    workspace_name="search-rescanned-workspace",
+                    workspace_path="/tmp/search-rescanned",
+                    messages=[ChatMessage(role="user", content="uniqueSearchBootstrapToken")],
+                    vscode_edition="cli",
+                    type="cli",
+                )
+            )
+            return None
+
+        with patch("copilot_session_tools.cli.enrich_single_session", side_effect=fake_enrich) as mock_enrich:
+            result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "--db",
+                    str(db_path),
+                    "uniqueSearchBootstrapToken",
+                    "--rescan-session",
+                    session_id,
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_enrich.assert_called_once()
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["session_id"] == session_id
 
 
 class TestSearchIncludeExclude:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,20 +271,17 @@ class TestCLI:
         output_dir = tmp_path / "markdown_output"
         session_id = "rescanned-session"
 
-        def fake_enrich(database, requested_session_id):
-            database.enrich_session(
-                ChatSession(
-                    session_id=requested_session_id,
-                    workspace_name="rescanned-workspace",
-                    workspace_path="/tmp/rescanned",
-                    messages=[ChatMessage(role="user", content="Fresh bootstrap content")],
-                    vscode_edition="cli",
-                    type="cli",
-                )
+        def fake_parse(requested_session_id):
+            return ChatSession(
+                session_id=requested_session_id,
+                workspace_name="rescanned-workspace",
+                workspace_path="/tmp/rescanned",
+                messages=[ChatMessage(role="user", content="Fresh bootstrap content")],
+                vscode_edition="cli",
+                type="cli",
             )
-            return None
 
-        with patch("copilot_session_tools.cli.enrich_single_session", side_effect=fake_enrich) as mock_enrich:
+        with patch("copilot_session_tools.cli.parse_single_cli_session", side_effect=fake_parse) as mock_parse:
             result = runner.invoke(
                 app,
                 [
@@ -301,20 +298,21 @@ class TestCLI:
             )
 
         assert result.exit_code == 0
-        mock_enrich.assert_called_once()
+        mock_parse.assert_called_once()
         assert db_path.exists()
         md_files = list(output_dir.glob("*.md"))
         assert len(md_files) == 1
         assert "Fresh bootstrap content" in md_files[0].read_text(encoding="utf-8")
 
-    def test_export_markdown_rescan_session_must_match_session_id(self, runner, temp_db_with_data, tmp_path):
+    def test_export_markdown_rescan_session_must_match_session_id(self, runner, tmp_path):
         """Session-scoped exports reject mismatched --rescan-session values."""
+        db_path = tmp_path / "missing.db"
         result = runner.invoke(
             app,
             [
                 "export-markdown",
                 "--db",
-                str(temp_db_with_data),
+                str(db_path),
                 "--output-dir",
                 str(tmp_path / "markdown_output"),
                 "--session-id",
@@ -326,16 +324,18 @@ class TestCLI:
 
         assert result.exit_code == 1
         assert "must match --session-id" in result.output
+        assert not db_path.exists()
 
-    def test_export_markdown_rescan_session_surfaces_enrichment_error(self, runner, temp_db_with_data, tmp_path):
+    def test_export_markdown_rescan_session_surfaces_enrichment_error(self, runner, tmp_path):
         """Targeted rescan failures stop the command before export."""
-        with patch("copilot_session_tools.cli.enrich_single_session", return_value="events.jsonl not found for session missing-session"):
+        db_path = tmp_path / "missing.db"
+        with patch("copilot_session_tools.cli.parse_single_cli_session", return_value="events.jsonl not found for session missing-session"):
             result = runner.invoke(
                 app,
                 [
                     "export-markdown",
                     "--db",
-                    str(temp_db_with_data),
+                    str(db_path),
                     "--output-dir",
                     str(tmp_path / "markdown_output"),
                     "--session-id",
@@ -347,6 +347,7 @@ class TestCLI:
 
         assert result.exit_code == 1
         assert "events.jsonl not found" in result.output
+        assert not db_path.exists()
 
     def test_export_html_command(self, runner, temp_db_with_data, tmp_path):
         """Test export-html command exports sessions to HTML files."""
@@ -433,20 +434,17 @@ class TestCLI:
         db_path = tmp_path / "missing.db"
         session_id = "search-rescanned-session"
 
-        def fake_enrich(database, requested_session_id):
-            database.enrich_session(
-                ChatSession(
-                    session_id=requested_session_id,
-                    workspace_name="search-rescanned-workspace",
-                    workspace_path="/tmp/search-rescanned",
-                    messages=[ChatMessage(role="user", content="uniqueSearchBootstrapToken")],
-                    vscode_edition="cli",
-                    type="cli",
-                )
+        def fake_parse(requested_session_id):
+            return ChatSession(
+                session_id=requested_session_id,
+                workspace_name="search-rescanned-workspace",
+                workspace_path="/tmp/search-rescanned",
+                messages=[ChatMessage(role="user", content="uniqueSearchBootstrapToken")],
+                vscode_edition="cli",
+                type="cli",
             )
-            return None
 
-        with patch("copilot_session_tools.cli.enrich_single_session", side_effect=fake_enrich) as mock_enrich:
+        with patch("copilot_session_tools.cli.parse_single_cli_session", side_effect=fake_parse) as mock_parse:
             result = runner.invoke(
                 app,
                 [
@@ -461,7 +459,7 @@ class TestCLI:
             )
 
         assert result.exit_code == 0
-        mock_enrich.assert_called_once()
+        mock_parse.assert_called_once()
         data = json.loads(result.output)
         assert len(data) == 1
         assert data[0]["session_id"] == session_id

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

| Area | Change |
| --- | --- |
| CLI | Add `--rescan-session <session-id>` to `search`, `export-markdown`, and `export-html` so a single CLI session can be parsed/enriched before the command runs. |
| Refresh internals | Add a parse-before-write helper so failed targeted rescans do not create empty CST databases. |
| Tests | Cover never-scanned session bootstrap, mismatch validation, enrichment failure handling, and clean JSON search output. |
| Docs | Update search skill and scanner-refresh agent guidance to prefer targeted rescans after Chronicle identifies a candidate session. |
| Release | Bump version to `0.15.1` and update changelog. |

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests/test_cli.py -v`
- `uv run pytest tests/ --ignore=tests/test_webapp_e2e.py -v`

## Review

- GPT review found failed rescans could create an empty DB before failing; fixed by parsing/validating before DB bootstrap.
- Second review agent failed due to model/API connectivity after retries; no result was produced.

## Breaking changes

None.
