### PR TITLE
feat: dedupe fork history in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-06-06
+
+### Added
+
+- **Search / Forks**: CLI event IDs are now persisted as message provenance so copied pre-fork history can be identified across forked sessions.
+
+### Changed
+
+- **Search / Forks**: Search now suppresses duplicate hits from copied fork history while keeping fork-specific continuations searchable. Opening or exporting a forked session still shows the full copied conversation.
+
 ## [0.15.1] - 2026-06-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.15.1"
+version = "0.16.0"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 from .content_types import (
     CONTENT_TYPES,

--- a/src/copilot_session_tools/db_retrieval.py
+++ b/src/copilot_session_tools/db_retrieval.py
@@ -170,6 +170,7 @@ def reconstruct_message(
         command_runs=command_runs,
         content_blocks=content_blocks,
         cached_markdown=cached_md,
+        source_event_id=msg_row["source_event_id"] if "source_event_id" in msg_row.keys() else None,  # noqa: SIM118
         agent_id=msg_row["agent_id"] if "agent_id" in msg_row.keys() else None,  # noqa: SIM118
         agent_display_name=msg_row["agent_display_name"] if "agent_display_name" in msg_row.keys() else None,  # noqa: SIM118
         agent_nesting_level=msg_row["agent_nesting_level"] if "agent_nesting_level" in msg_row.keys() else 0,  # noqa: SIM118
@@ -282,6 +283,7 @@ def get_cst_session(conn: sqlite3.Connection, session_id: str) -> ChatSession | 
             command_runs=cmds_by_msg.get(msg_id, []),
             content_blocks=content_blocks,
             cached_markdown=cached_md,
+            source_event_id=msg_row["source_event_id"] if "source_event_id" in msg_row.keys() else None,  # noqa: SIM118
             agent_id=msg_row["agent_id"] if "agent_id" in msg_row.keys() else None,  # noqa: SIM118
             agent_display_name=msg_row["agent_display_name"] if "agent_display_name" in msg_row.keys() else None,  # noqa: SIM118
             agent_nesting_level=msg_row["agent_nesting_level"] if "agent_nesting_level" in msg_row.keys() else 0,  # noqa: SIM118

--- a/src/copilot_session_tools/db_schema.py
+++ b/src/copilot_session_tools/db_schema.py
@@ -43,9 +43,12 @@ CST_MESSAGE_COLUMNS = (
     "content",
     "timestamp",
     "cached_markdown",
+    "source_event_id",
     "agent_id",
     "agent_display_name",
     "agent_nesting_level",
+    "original_content",
+    "cleanup_model",
     "parent_message_id",
     "child_index",
 )

--- a/src/copilot_session_tools/db_search.py
+++ b/src/copilot_session_tools/db_search.py
@@ -391,6 +391,30 @@ def _append_session_filters(
     return query
 
 
+def _fork_duplicate_filter_clause(duplicate_content_clause: str = "COALESCE(dm.content, '') = COALESCE(m.content, '')") -> str:
+    """Return SQL that keeps only the canonical session row for copied fork events."""
+    return f"""
+        AND (
+            m.source_event_id IS NULL
+            OR NOT EXISTS (
+                SELECT 1
+                FROM cst_messages dm
+                JOIN cst_sessions ds ON dm.session_id = ds.session_id
+                WHERE dm.source_event_id = m.source_event_id
+                  AND dm.session_id != m.session_id
+                  AND ({duplicate_content_clause})
+                  AND (
+                      COALESCE(ds.created_at, '') < COALESCE(s.created_at, '')
+                      OR (
+                          COALESCE(ds.created_at, '') = COALESCE(s.created_at, '')
+                          AND ds.session_id < s.session_id
+                      )
+                  )
+            )
+        )
+    """  # noqa: S608 — duplicate_content_clause is built from hardcoded column names
+
+
 def _search_builtin_index(conn: sqlite3.Connection, fts_query: str, limit: int) -> dict[str, dict]:
     """Search the Chronicle search_index FTS table for unenriched results.
 
@@ -530,6 +554,7 @@ def _search_messages(
             message_query += " AND m.role != 'system'"
 
         message_query = _append_session_filters(message_query, params, **filter_kwargs)
+        message_query += _fork_duplicate_filter_clause()
 
         order_clause = _SORT_ORDER_CLAUSES.get(sort_by, _SORT_ORDER_CLAUSES["relevance"])
         message_query += f" {order_clause} LIMIT ?"
@@ -566,6 +591,7 @@ def _search_messages(
             message_query += " AND m.role != 'system'"
 
         message_query = _append_session_filters(message_query, params, **filter_kwargs)
+        message_query += _fork_duplicate_filter_clause()
 
         message_query += " ORDER BY s.created_at DESC LIMIT ?"
         params.append(limit + skip)
@@ -613,6 +639,18 @@ def _search_tool_invocations(
     params: list = list(tool_params)
 
     tool_query = _append_session_filters(tool_query, params, **filter_kwargs)
+    tool_query += _fork_duplicate_filter_clause(
+        """
+        EXISTS (
+            SELECT 1
+            FROM cst_tool_invocations dt
+            WHERE dt.message_id = dm.id
+              AND COALESCE(dt.name, '') = COALESCE(t.name, '')
+              AND COALESCE(dt.input, '') = COALESCE(t.input, '')
+              AND COALESCE(dt.result, '') = COALESCE(t.result, '')
+        )
+        """
+    )
 
     tool_query += " LIMIT ?"
     params.append(remaining)
@@ -658,6 +696,18 @@ def _search_file_changes(
     params: list = list(file_params)
 
     file_query = _append_session_filters(file_query, params, **filter_kwargs)
+    file_query += _fork_duplicate_filter_clause(
+        """
+        EXISTS (
+            SELECT 1
+            FROM cst_file_changes df
+            WHERE df.message_id = dm.id
+              AND COALESCE(df.path, '') = COALESCE(f.path, '')
+              AND COALESCE(df.explanation, '') = COALESCE(f.explanation, '')
+              AND COALESCE(df.diff, '') = COALESCE(f.diff, '')
+        )
+        """
+    )
 
     file_query += " LIMIT ?"
     params.append(remaining)
@@ -694,6 +744,17 @@ def _search_command_runs(
     params: list = [like_pattern, like_pattern]
 
     cmd_query = _append_session_filters(cmd_query, params, **filter_kwargs)
+    cmd_query += _fork_duplicate_filter_clause(
+        """
+        EXISTS (
+            SELECT 1
+            FROM cst_command_runs dc
+            WHERE dc.message_id = dm.id
+              AND COALESCE(dc.command, '') = COALESCE(c.command, '')
+              AND COALESCE(dc.output, '') = COALESCE(c.output, '')
+        )
+        """
+    )
 
     cmd_query += " LIMIT ?"
     params.append(remaining)
@@ -730,6 +791,17 @@ def _search_thinking_blocks(
     params: list = [like_pattern]
 
     think_query = _append_session_filters(think_query, params, **filter_kwargs)
+    think_query += _fork_duplicate_filter_clause(
+        """
+        EXISTS (
+            SELECT 1
+            FROM cst_content_blocks dcb
+            WHERE dcb.message_id = dm.id
+              AND dcb.kind = 'thinking'
+              AND COALESCE(dcb.content, '') = COALESCE(cb.content, '')
+        )
+        """
+    )
 
     think_query += " LIMIT ?"
     params.append(remaining)

--- a/src/copilot_session_tools/db_storage.py
+++ b/src/copilot_session_tools/db_storage.py
@@ -31,7 +31,7 @@ from .db_schema import (
 from .markdown_exporter import message_to_markdown
 from .scanner import ChatSession
 
-CST_SCHEMA_VERSION = 10
+CST_SCHEMA_VERSION = 11
 CHRONICLE_SCHEMA_VERSION = 4
 
 
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS cst_messages (
     content TEXT,
     timestamp TEXT,
     cached_markdown TEXT,
+    source_event_id TEXT,
     agent_id TEXT,
     agent_display_name TEXT,
     agent_nesting_level INTEGER DEFAULT 0,
@@ -78,6 +79,7 @@ CREATE TABLE IF NOT EXISTS cst_messages (
 );
 CREATE INDEX IF NOT EXISTS idx_cst_messages_session ON cst_messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_cst_messages_parent ON cst_messages(parent_message_id);
+CREATE INDEX IF NOT EXISTS idx_cst_messages_source_event ON cst_messages(source_event_id);
 
 CREATE TABLE IF NOT EXISTS cst_tool_invocations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -355,6 +357,12 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     except sqlite3.OperationalError:
         has_schema = False
 
+    if has_schema and current_version < 11:
+        # CST_SCHEMA creates an index on this column, so the column must exist
+        # before replaying the idempotent schema script against upgraded DBs.
+        with contextlib.suppress(sqlite3.OperationalError):
+            cursor.execute("ALTER TABLE cst_messages ADD COLUMN source_event_id TEXT")
+
     # Create cst_* tables (safe: either fresh DB or already at v6+)
     conn.executescript(CST_SCHEMA)
     # Create FTS table and triggers
@@ -391,6 +399,9 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         # v9 → v10: Add session context history storage.
         if current_version < 10:
             conn.executescript(CST_SCHEMA)
+        # v10 → v11: Add CLI source event ids for fork-aware search de-duplication.
+        if current_version < 11:
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_cst_messages_source_event ON cst_messages(source_event_id)")
         cursor.execute(
             "UPDATE cst_schema_version SET version = ?",
             (CST_SCHEMA_VERSION,),
@@ -595,9 +606,12 @@ def _insert_content_blocks_recursive(
                     child.content,
                     child.timestamp,
                     child_cached_md,
+                    child.source_event_id,
                     child.agent_id,
                     child.agent_display_name,
                     child.agent_nesting_level,
+                    child.original_content,
+                    child.cleanup_model,
                     parent_message_id,  # parent_message_id = parent's ID
                     block_idx,  # child_index = block position for ordering
                 ),
@@ -680,9 +694,12 @@ def add_session_impl(cursor: sqlite3.Cursor, session: ChatSession) -> None:
                 msg.content,
                 msg.timestamp,
                 cached_markdown,
+                msg.source_event_id,
                 msg.agent_id,
                 msg.agent_display_name,
                 msg.agent_nesting_level,
+                msg.original_content,
+                msg.cleanup_model,
                 None,  # parent_message_id — set by db-insertion todo
                 msg.child_index,
             ),
@@ -985,9 +1002,12 @@ def enrich_session(conn: sqlite3.Connection, session: ChatSession) -> None:
                 msg.content,
                 msg.timestamp,
                 cached_markdown,
+                msg.source_event_id,
                 msg.agent_id,
                 msg.agent_display_name,
                 msg.agent_nesting_level,
+                msg.original_content,
+                msg.cleanup_model,
                 None,  # parent_message_id — set by db-insertion todo
                 msg.child_index,
             ),

--- a/src/copilot_session_tools/scanner/cli.py
+++ b/src/copilot_session_tools/scanner/cli.py
@@ -350,7 +350,13 @@ class _CliSessionBuilder:
         self.current_assistant_tool_invocations: list[ToolInvocation] = []
         self.current_assistant_command_runs: list[CommandRun] = []
         self.current_assistant_timestamp: str | None = None
+        self.current_assistant_source_event_id: str | None = None
         self.pending_tool_requests: dict[str, dict] = {}
+
+    def note_assistant_event(self, event_id: object) -> None:
+        """Remember the first source event id that contributes to the current assistant message."""
+        if self.current_assistant_source_event_id is None and isinstance(event_id, str) and event_id:
+            self.current_assistant_source_event_id = event_id
 
     def flush_assistant_message(self) -> None:
         """Flush accumulated assistant content blocks into a single message."""
@@ -379,6 +385,7 @@ class _CliSessionBuilder:
                 role="assistant",
                 content=flat_content,
                 timestamp=self.current_assistant_timestamp,
+                source_event_id=self.current_assistant_source_event_id,
                 tool_invocations=self.current_assistant_tool_invocations.copy(),
                 command_runs=self.current_assistant_command_runs.copy(),
                 content_blocks=self.current_assistant_content_blocks.copy(),
@@ -391,6 +398,7 @@ class _CliSessionBuilder:
         self.current_assistant_tool_invocations = []
         self.current_assistant_command_runs = []
         self.current_assistant_timestamp = None
+        self.current_assistant_source_event_id = None
 
     def build_tool_invocation(self, tool_call_id: str, tool_name: str, arguments: object) -> tuple[ToolInvocation | None, CommandRun | None]:
         """Build a ToolInvocation or CommandRun from tool request data."""
@@ -890,6 +898,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                         role="user",
                         content=content,
                         timestamp=timestamp,
+                        source_event_id=event.get("id"),
                     )
                 )
 
@@ -905,6 +914,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                             role="system",
                             content=content,
                             timestamp=timestamp,
+                            source_event_id=event.get("id"),
                         )
                     )
 
@@ -919,6 +929,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 # Set timestamp from first assistant message in the sequence
                 if builder.current_assistant_timestamp is None:
                     builder.current_assistant_timestamp = timestamp
+                builder.note_assistant_event(event.get("id"))
 
                 content = event_data.get("content", "")
                 tool_requests = event_data.get("toolRequests", [])
@@ -950,6 +961,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                         builder.pending_tool_requests[tool_call_id] = req
 
             elif event_type == "tool.execution_start":
+                builder.note_assistant_event(event.get("id"))
                 # Add the tool invocation inline when execution starts
                 tool_call_id = event_data.get("toolCallId")
                 tool_name = event_data.get("toolName", "unknown")
@@ -969,6 +981,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 builder.add_tool_inline(tool_call_id, tool_name, arguments, intention_summary=intention_summary, tool_title=tool_title)
 
             elif event_type == "abort":
+                builder.note_assistant_event(event.get("id"))
                 # Session or turn was aborted - add as status block
                 abort_reason = event_data.get("reason", "unknown")
                 builder.current_assistant_content_blocks.append(
@@ -980,6 +993,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 )
 
             elif event_type == "session.error":
+                builder.note_assistant_event(event.get("id"))
                 # Session encountered an error - add as status block
                 error_type = event_data.get("errorType", "unknown")
                 error_message = event_data.get("message", "")
@@ -992,6 +1006,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 )
 
             elif event_type == "session.model_change":
+                builder.note_assistant_event(event.get("id"))
                 # Model was changed during session
                 new_model = event_data.get("newModel", "unknown")
                 builder.current_assistant_content_blocks.append(
@@ -1003,6 +1018,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 )
 
             elif event_type == "assistant.reasoning":
+                builder.note_assistant_event(event.get("id"))
                 # Reasoning content - similar to VS Code thinking blocks
                 reasoning_content = event_data.get("content", "")
                 if reasoning_content and reasoning_content.strip():
@@ -1015,6 +1031,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                     )
 
             elif event_type == "assistant.intent":
+                builder.note_assistant_event(event.get("id"))
                 intent_text = (event_data.get("intent") or "").strip()
                 if intent_text:
                     builder.current_assistant_content_blocks.append(
@@ -1025,6 +1042,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                     )
 
             elif event_type == "skill.invoked":
+                builder.note_assistant_event(event.get("id"))
                 # Skill was loaded - show name and content summary
                 skill_name = event_data.get("name", "unknown")
                 skill_content = event_data.get("content", "")
@@ -1044,6 +1062,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 )
 
             elif event_type == "session.compaction_complete":
+                builder.note_assistant_event(event.get("id"))
                 # Session was compacted - show checkpoint info
                 checkpoint_num = event_data.get("checkpointNumber", 0)
                 summary = event_data.get("summaryContent", "")
@@ -1065,6 +1084,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
 
             # --- Subagent lifecycle events ---
             elif event_type == "subagent.started":
+                builder.note_assistant_event(event.get("id"))
                 display_name = event_data.get("agentDisplayName") or event_data.get("agentName", "unknown")
                 tool_call_id = event_data.get("toolCallId", "")
                 req = builder.pending_tool_requests.get(tool_call_id, {})
@@ -1150,6 +1170,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                     agent_display_name=title,
                     # TODO: For multi-level nesting, derive from parent's nesting level
                     agent_nesting_level=1,
+                    source_event_id=builder.current_assistant_source_event_id,
                     tool_invocations=nested_tool_invocations,
                     command_runs=nested_command_runs,
                     content_blocks=nested_blocks,
@@ -1171,6 +1192,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 builder.current_assistant_content_blocks.append(block)
 
             elif event_type == "subagent.completed":
+                builder.note_assistant_event(event.get("id"))
                 display_name = event_data.get("agentDisplayName") or event_data.get("agentName", "unknown")
                 tool_call_id = event_data.get("toolCallId", "")
                 req = builder.pending_tool_requests.get(tool_call_id, {})
@@ -1180,6 +1202,7 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=label, description="subagent"))
 
             elif event_type == "subagent.failed":
+                builder.note_assistant_event(event.get("id"))
                 display_name = event_data.get("agentDisplayName") or event_data.get("agentName", "unknown")
                 tool_call_id = event_data.get("toolCallId", "")
                 req = builder.pending_tool_requests.get(tool_call_id, {})

--- a/src/copilot_session_tools/scanner/models.py
+++ b/src/copilot_session_tools/scanner/models.py
@@ -116,6 +116,7 @@ class ChatMessage:
     command_runs: list[CommandRun] = field(default_factory=list)
     content_blocks: list[ContentBlock] = field(default_factory=list)  # Structured content with kind
     cached_markdown: str | None = None  # Pre-computed markdown for this message
+    source_event_id: str | None = None  # CLI event id used to identify copied fork history
     agent_id: str | None = None  # toolCallId linking to parent task tool invocation
     agent_display_name: str | None = None  # "General Purpose Agent", "Explore Agent", etc.
     agent_nesting_level: int = 0  # 0=top-level, 1=inside agent, 2=nested agent, etc.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -364,6 +364,186 @@ class TestDatabase:
         assert len(results) > 0
         assert any("Python" in r["content"] for r in results)
 
+    def test_search_deduplicates_copied_fork_history_by_source_event_id(self, temp_db):
+        """Test search suppresses copied fork history while keeping new fork content."""
+        original = ChatSession(
+            session_id="original-session",
+            workspace_name="project",
+            workspace_path="/tmp/project",
+            created_at="2026-01-01T00:00:00Z",
+            messages=[
+                ChatMessage(
+                    role="user",
+                    content="shared fork setup unique text",
+                    source_event_id="evt-shared-user",
+                ),
+                ChatMessage(
+                    role="assistant",
+                    content="original continuation unique text",
+                    source_event_id="evt-original-continuation",
+                ),
+            ],
+        )
+        fork = ChatSession(
+            session_id="fork-session",
+            workspace_name="project-fork",
+            workspace_path="/tmp/project-fork",
+            created_at="2026-01-01T00:10:00Z",
+            messages=[
+                ChatMessage(
+                    role="user",
+                    content="shared fork setup unique text",
+                    source_event_id="evt-shared-user",
+                ),
+                ChatMessage(
+                    role="assistant",
+                    content="fork continuation unique text",
+                    source_event_id="evt-fork-continuation",
+                ),
+            ],
+        )
+        temp_db.add_session(original)
+        temp_db.add_session(fork)
+
+        shared_results = temp_db.search('"shared fork setup unique text"', search_content_set={"messages"})
+        assert [result["session_id"] for result in shared_results] == ["original-session"]
+
+        fork_results = temp_db.search('"fork continuation unique text"', search_content_set={"messages"})
+        assert [result["session_id"] for result in fork_results] == ["fork-session"]
+
+        original_results = temp_db.search('"original continuation unique text"', search_content_set={"messages"})
+        assert [result["session_id"] for result in original_results] == ["original-session"]
+
+    def test_search_keeps_independent_duplicate_content_with_distinct_event_ids(self, temp_db):
+        """Test identical text remains searchable when it is not copied fork history."""
+        first = ChatSession(
+            session_id="first-independent-session",
+            workspace_name="project-a",
+            workspace_path="/tmp/project-a",
+            created_at="2026-01-01T00:00:00Z",
+            messages=[
+                ChatMessage(
+                    role="user",
+                    content="independent duplicate text",
+                    source_event_id="evt-first-independent",
+                )
+            ],
+        )
+        second = ChatSession(
+            session_id="second-independent-session",
+            workspace_name="project-b",
+            workspace_path="/tmp/project-b",
+            created_at="2026-01-01T00:10:00Z",
+            messages=[
+                ChatMessage(
+                    role="user",
+                    content="independent duplicate text",
+                    source_event_id="evt-second-independent",
+                )
+            ],
+        )
+        temp_db.add_session(first)
+        temp_db.add_session(second)
+
+        results = temp_db.search('"independent duplicate text"', search_content_set={"messages"}, sort_by="date")
+
+        assert {result["session_id"] for result in results} == {
+            "first-independent-session",
+            "second-independent-session",
+        }
+
+    def test_search_keeps_divergent_content_with_shared_source_event_id(self, temp_db):
+        """Test a fork continuation is searchable when only part of an assistant row diverged."""
+        original = ChatSession(
+            session_id="original-divergent-session",
+            workspace_name="project",
+            workspace_path="/tmp/project",
+            created_at="2026-01-01T00:00:00Z",
+            messages=[
+                ChatMessage(
+                    role="assistant",
+                    content="shared assistant content",
+                    source_event_id="evt-shared-assistant",
+                )
+            ],
+        )
+        fork = ChatSession(
+            session_id="fork-divergent-session",
+            workspace_name="project-fork",
+            workspace_path="/tmp/project-fork",
+            created_at="2026-01-01T00:10:00Z",
+            messages=[
+                ChatMessage(
+                    role="assistant",
+                    content="shared assistant content plus fork-only divergent text",
+                    source_event_id="evt-shared-assistant",
+                )
+            ],
+        )
+        temp_db.add_session(original)
+        temp_db.add_session(fork)
+
+        results = temp_db.search('"fork-only divergent text"', search_content_set={"messages"})
+
+        assert [result["session_id"] for result in results] == ["fork-divergent-session"]
+
+    def test_search_deduplicates_copied_fork_artifacts_by_source_event_id(self, temp_db):
+        """Test copied pre-fork tools, files, commands, and thinking blocks are de-duplicated."""
+        shared_message = "shared assistant artifact holder"
+        original = ChatSession(
+            session_id="original-artifact-session",
+            workspace_name="project",
+            workspace_path="/tmp/project",
+            created_at="2026-01-01T00:00:00Z",
+            messages=[
+                ChatMessage(
+                    role="assistant",
+                    content=shared_message,
+                    source_event_id="evt-shared-artifacts",
+                    tool_invocations=[ToolInvocation(name="search_tool", input="tool duplicate target", result="found copied result")],
+                    file_changes=[FileChange(path="src/copied_target.py", explanation="file duplicate target", diff="+ copied diff target")],
+                    command_runs=[CommandRun(command="run copied command target", output="command duplicate target")],
+                    content_blocks=[
+                        ContentBlock(kind="thinking", content="thinking duplicate target"),
+                        ContentBlock(kind="text", content=shared_message),
+                    ],
+                )
+            ],
+        )
+        fork = ChatSession(
+            session_id="fork-artifact-session",
+            workspace_name="project-fork",
+            workspace_path="/tmp/project-fork",
+            created_at="2026-01-01T00:10:00Z",
+            messages=[
+                ChatMessage(
+                    role="assistant",
+                    content=shared_message,
+                    source_event_id="evt-shared-artifacts",
+                    tool_invocations=[ToolInvocation(name="search_tool", input="tool duplicate target", result="found copied result")],
+                    file_changes=[FileChange(path="src/copied_target.py", explanation="file duplicate target", diff="+ copied diff target")],
+                    command_runs=[CommandRun(command="run copied command target", output="command duplicate target")],
+                    content_blocks=[
+                        ContentBlock(kind="thinking", content="thinking duplicate target"),
+                        ContentBlock(kind="text", content=shared_message),
+                    ],
+                )
+            ],
+        )
+        temp_db.add_session(original)
+        temp_db.add_session(fork)
+
+        cases = [
+            ("tool duplicate target", {"tools", "tool-inputs"}),
+            ("file duplicate target", {"file-changes"}),
+            ("copied diff target", {"file-changes", "diffs"}),
+            ("command duplicate target", {"commands"}),
+            ("thinking duplicate target", {"thinking"}),
+        ]
+        for query, search_content_set in cases:
+            results = temp_db.search(query, search_content_set=search_content_set)
+            assert [result["session_id"] for result in results] == ["original-artifact-session"]
+
     def test_search_no_results(self, temp_db, sample_session):
         """Test search with no matching results."""
         temp_db.add_session(sample_session)
@@ -2486,6 +2666,27 @@ class TestSchemaV6:
         msg_cols = {row[1] for row in conn.execute("PRAGMA table_info(cst_messages)")}
         assert "parent_message_id" in msg_cols
         assert "child_index" in msg_cols
+
+        conn.close()
+
+    def test_v10_to_v11_migration_adds_source_event_id_before_index(self):
+        """Simulating a v10 DB adds source_event_id before replaying current indexes."""
+        from copilot_session_tools.db_storage import CST_SCHEMA_VERSION, ensure_schema
+
+        conn = sqlite3.connect(":memory:")
+        ensure_schema(conn)
+        conn.execute("DROP INDEX IF EXISTS idx_cst_messages_source_event")
+        conn.execute("ALTER TABLE cst_messages DROP COLUMN source_event_id")
+        conn.execute("UPDATE cst_schema_version SET version = 10")
+
+        ensure_schema(conn)
+
+        msg_cols = {row[1] for row in conn.execute("PRAGMA table_info(cst_messages)")}
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list(cst_messages)")}
+        version = conn.execute("SELECT version FROM cst_schema_version").fetchone()[0]
+        assert "source_event_id" in msg_cols
+        assert "idx_cst_messages_source_event" in indexes
+        assert version == CST_SCHEMA_VERSION
 
         conn.close()
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -478,6 +478,42 @@ class TestCLIParsing:
         # This is expected - the simple format was for testing only
         assert session is None
 
+    def test_parse_cli_jsonl_captures_source_event_ids(self, tmp_path):
+        """Test CLI event ids are retained for fork-aware search de-duplication."""
+        from copilot_session_tools.scanner import _parse_cli_jsonl_file
+
+        events = [
+            {
+                "type": "session.start",
+                "data": {"sessionId": "source-id-test", "startTime": "2026-01-01T00:00:00Z"},
+            },
+            {
+                "id": "evt-user-1",
+                "type": "user.message",
+                "timestamp": "2026-01-01T00:00:01Z",
+                "data": {"content": "Hello provenance"},
+            },
+            {
+                "id": "evt-assistant-1",
+                "type": "assistant.message",
+                "timestamp": "2026-01-01T00:00:02Z",
+                "data": {"content": "Hi with provenance"},
+            },
+            {
+                "id": "evt-user-2",
+                "type": "user.message",
+                "timestamp": "2026-01-01T00:00:03Z",
+                "data": {"content": "Next turn"},
+            },
+        ]
+        events_file = tmp_path / "events.jsonl"
+        events_file.write_text("\n".join(json.dumps(event) for event in events), encoding="utf-8")
+
+        session = _parse_cli_jsonl_file(events_file)
+
+        assert session is not None
+        assert [msg.source_event_id for msg in session.messages] == ["evt-user-1", "evt-assistant-1", "evt-user-2"]
+
     def test_get_cli_storage_paths(self):
         """Test getting CLI storage paths."""
         from copilot_session_tools import get_cli_storage_paths

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

| Area | Change |
|---|---|
| Scanner | Captures CLI event IDs as message provenance (`source_event_id`). |
| Database | Persists provenance with schema v11 migration and retrieval support. |
| Search | Suppresses duplicate copied fork-history hits while preserving fork-specific continuations and full session rendering/export. |
| Release | Bumps package/changelog to `0.16.0`. |

## Review fixes

- Fixed upgrade ordering so existing v10 databases get `source_event_id` before the new index is replayed.
- Made fork duplicate suppression content/artifact-aware so divergent fork content with the same first assistant event ID remains searchable.
- Extended de-dupe to tool, file, command, and thinking searches that join through messages.

## Validation

- `uv run pytest` — 874 passed, 13 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- Tri-review completed; high findings addressed.

## Breaking changes

None expected. Existing unenriched or partially enriched fork families remain searchable conservatively until both copies are enriched.