### PR TITLE
Render external (host-app) tools with their parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-08-06
+
+### Changed
+
+- **Scanner / Web Viewer**: External (host-app) tools (`external_tool.requested` / `external_tool.completed`) now render as collapsible tool blocks that expose their parameters, instead of a one-line status breadcrumb. Because the host application runs these tools and never returns a result into the session, the block shows an explicit "Response: Not recorded" note, and an `external tool` badge distinguishes them from CLI tools. Affects the web viewer and HTML export.
+
 ## [0.17.1] - 2026-06-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "copilot-session-tools"
-version = "0.17.1"
+version = "0.18.0"
 description = "A collection of tools for VS Code GitHub Copilot chat history"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/copilot_session_tools/__init__.py
+++ b/src/copilot_session_tools/__init__.py
@@ -12,7 +12,7 @@ This project borrows patterns from several open-source projects:
 - tad-hq/universal-session-viewer: FTS5 full-text search design
 """
 
-__version__ = "0.17.1"
+__version__ = "0.18.0"
 
 from .content_types import (
     CONTENT_TYPES,

--- a/src/copilot_session_tools/scanner/cli.py
+++ b/src/copilot_session_tools/scanner/cli.py
@@ -179,11 +179,6 @@ def _format_session_event_status(event_type: str, event_data: dict) -> tuple[str
         return f"Command executed: {command}" if command else "Command executed", "command"
     if event_type == "command.completed":
         return "Command completed", "command"
-    if event_type == "external_tool.requested":
-        tool_name = _stringify_event_value(event_data.get("toolName"))
-        return f"External tool requested: {tool_name}" if tool_name else "External tool requested", "external-tool"
-    if event_type == "external_tool.completed":
-        return "External tool completed", "external-tool"
     if event_type == "hook.end" and not event_data.get("success", True):
         hook_type = _stringify_event_value(event_data.get("hookType"))
         error = _stringify_event_value(event_data.get("error"))
@@ -641,6 +636,36 @@ class _CliSessionBuilder:
                 )
             )
             self.current_assistant_tool_invocations.append(tool_inv)
+
+    def add_external_tool_inline(self, tool_call_id: str, tool_name: str, arguments: object) -> None:
+        """Add an external (host-app) tool invocation inline in the current assistant message.
+
+        External tools come from ``external_tool.requested`` events. The request carries the
+        tool name and its ``arguments`` (parameters), but the paired ``external_tool.completed``
+        event is a bare acknowledgement with no result payload — the host application executes
+        these tools and does not record a response back into the session. We therefore render the
+        parameters (previously discarded) and leave ``result`` unset; the template surfaces a note
+        explaining that no response was recorded.
+        """
+        argument_dict = _as_tool_argument_dict(arguments)
+        description = _get_tool_arg_str(argument_dict, "description") or None
+        invocation_message = _format_tool_display_message(tool_name, argument_dict, description)
+        tool_inv = ToolInvocation(
+            name=tool_name,
+            input=_serialize_tool_arguments(arguments),
+            result=None,
+            status=None,
+            invocation_message=invocation_message,
+            source_type="external",
+        )
+        self.current_assistant_content_blocks.append(
+            ContentBlock(
+                kind="toolInvocation",
+                content=invocation_message or tool_name,
+                description=description or tool_name,
+            )
+        )
+        self.current_assistant_tool_invocations.append(tool_inv)
 
 
 def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
@@ -1396,6 +1421,17 @@ def _parse_cli_jsonl_file(file_path: Path) -> ChatSession | None:
                 answer = _stringify_event_value(event_data.get("answer"))
                 if answer:
                     builder.current_assistant_content_blocks.append(ContentBlock(kind="status", content=f"User answered: {answer}", description="user-input"))
+
+            elif event_type == "external_tool.requested":
+                # Host-app tool invoked outside the CLI. The request carries the parameters;
+                # render them as a proper tool block instead of a bare status breadcrumb.
+                ext_tool_name = _stringify_event_value(event_data.get("toolName"))
+                ext_tool_call_id = _stringify_event_value(event_data.get("toolCallId"))
+                builder.add_external_tool_inline(ext_tool_call_id, ext_tool_name, event_data.get("arguments", {}))
+
+            elif event_type == "external_tool.completed":
+                # Bare acknowledgement (only carries requestId) — no result payload to render.
+                pass
 
             elif formatted_status := _format_session_event_status(event_type, event_data):
                 content, description = formatted_status

--- a/src/copilot_session_tools/web/templates/session.html
+++ b/src/copilot_session_tools/web/templates/session.html
@@ -1390,6 +1390,30 @@ header h1 {
     margin-bottom: 4px;
 }
 
+.tool-no-response {
+    display: block;
+    font-size: 0.85em;
+    font-style: italic;
+    color: var(--text-secondary);
+    opacity: 0.85;
+}
+
+.external-tool-badge {
+    display: inline-block;
+    font-size: 0.72em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--text-secondary);
+    background: var(--bg-secondary, rgba(127, 127, 127, 0.12));
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    padding: 1px 6px;
+    margin-right: 6px;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
 .tool-section pre {
     margin: 0;
     padding: 10px;
@@ -3099,9 +3123,11 @@ input:checked + .toggle-switch::after {
                             {# - run_in_terminal (has command input and terminal output) #}
                             {# Internal file tools (copilot_readFile, etc.) just show pretty invocation message #}
                             {% set is_mcp_tool = matched_tool.source_type == 'mcp' %}
+                            {% set is_external_tool = matched_tool.source_type == 'external' %}
                             {% set is_terminal_tool = matched_tool.name == 'run_in_terminal' %}
                             {% set has_tool_details = matched_tool.input or matched_tool.result %}
-                            {% set show_collapsible = (is_mcp_tool or is_terminal_tool) and has_tool_details %}
+                            {# External (host-app) tools are always collapsible so the "no response recorded" note is shown, even when they take no parameters. #}
+                            {% set show_collapsible = ((is_mcp_tool or is_terminal_tool) and has_tool_details) or is_external_tool %}
                             
                             {# Determine the pretty header text - use invocation_message if available, else block content #}
                             {% set pretty_header = matched_tool.invocation_message if matched_tool.invocation_message else block.content %}
@@ -3156,6 +3182,7 @@ input:checked + .toggle-switch::after {
                                 <details class="tool-invocation-wrapper" open>
                                     <summary>
                                         <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        {% if is_external_tool %}<span class="external-tool-badge">external tool</span>{% endif %}
                                         <span class="tool-invocation-message">{{ pretty_header | markdown | safe }}</span>
                                         {% if matched_tool.status %}
                                         <span class="status-badge {{ matched_tool.status }}">{{ matched_tool.status }}</span>
@@ -3181,6 +3208,11 @@ input:checked + .toggle-switch::after {
                                         <div class="tool-section tool-section-output">
                                             <span class="tool-label">Output:</span>
                                             <pre><code>{{ highlight_code(tool_out, tool_out_lang) }}</code></pre>
+                                        </div>
+                                        {% elif is_external_tool %}
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
                                         </div>
                                         {% endif %}
                                     </div>
@@ -3225,7 +3257,7 @@ input:checked + .toggle-switch::after {
                 {# Show unmatched tool invocations #}
                 {% set unmatched_tools = [] %}
                 {% for tool in tool_invocations %}
-                    {% set is_collapsible_tool = (tool.source_type == 'mcp' or tool.name == 'run_in_terminal') and (tool.input or tool.result) %}
+                    {% set is_collapsible_tool = ((tool.source_type == 'mcp' or tool.name == 'run_in_terminal') and (tool.input or tool.result)) or tool.source_type == 'external' %}
                     {% if tool.name not in (meta.get('matched_tool_names', []) if meta else []) and is_collapsible_tool %}
                         {% set _ = unmatched_tools.append(tool) %}
                     {% endif %}
@@ -3243,6 +3275,7 @@ input:checked + .toggle-switch::after {
                         <details class="tool-invocation-wrapper" open>
                             <summary>
                                 <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                {% if tool.source_type == 'external' %}<span class="external-tool-badge">external tool</span>{% endif %}
                                 {% if tool.invocation_message %}
                                 <span class="tool-invocation-message">{{ tool.invocation_message | markdown | safe }}</span>
                                 {% else %}
@@ -3272,6 +3305,11 @@ input:checked + .toggle-switch::after {
                                 <div class="tool-section tool-section-output">
                                     <span class="tool-label">Output:</span>
                                     <pre><code>{{ highlight_code(utool_out, utool_out_lang) }}</code></pre>
+                                </div>
+                                {% elif tool.source_type == 'external' %}
+                                <div class="tool-section tool-section-output tool-section-no-response">
+                                    <span class="tool-label">Response:</span>
+                                    <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
                                 </div>
                                 {% endif %}
                             </div>

--- a/tests/snapshots/baselines/cli-with-agents.html
+++ b/tests/snapshots/baselines/cli-with-agents.html
@@ -1331,6 +1331,30 @@ header h1 {
     margin-bottom: 4px;
 }
 
+.tool-no-response {
+    display: block;
+    font-size: 0.85em;
+    font-style: italic;
+    color: var(--text-secondary);
+    opacity: 0.85;
+}
+
+.external-tool-badge {
+    display: inline-block;
+    font-size: 0.72em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--text-secondary);
+    background: var(--bg-secondary, rgba(127, 127, 127, 0.12));
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    padding: 1px 6px;
+    margin-right: 6px;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
 .tool-section pre {
     margin: 0;
     padding: 10px;
@@ -2342,6 +2366,8 @@ input:checked + .toggle-switch::after {
                             
                             
                             
+                            
+                            
                             <div class="content-block content-block-toolInvocation tool-invocation-unmatched">
                                 <div class="tool-invocation-message"><p>Searching for <code>jwt.decode</code> in ``</p></div>
                             </div>
@@ -2373,6 +2399,8 @@ input:checked + .toggle-switch::after {
                             
                             
                             
+                            
+                            
                             <div class="content-block content-block-toolInvocation tool-invocation-unmatched">
                                 <div class="tool-invocation-message"><p>Viewing <code>jwt.py</code></p></div>
                             </div>
@@ -2381,6 +2409,8 @@ input:checked + .toggle-switch::after {
                             
                             
                         
+                            
+                            
                             
                             
                             
@@ -2540,6 +2570,8 @@ tests/test_auth.py::test_expired PASSED
                     
                         
                         
+                            
+                            
                             
                             
                             

--- a/tests/snapshots/baselines/cli-with-async-shells.html
+++ b/tests/snapshots/baselines/cli-with-async-shells.html
@@ -1331,6 +1331,30 @@ header h1 {
     margin-bottom: 4px;
 }
 
+.tool-no-response {
+    display: block;
+    font-size: 0.85em;
+    font-style: italic;
+    color: var(--text-secondary);
+    opacity: 0.85;
+}
+
+.external-tool-badge {
+    display: inline-block;
+    font-size: 0.72em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--text-secondary);
+    background: var(--bg-secondary, rgba(127, 127, 127, 0.12));
+    border: 1px solid var(--border-color, rgba(127, 127, 127, 0.3));
+    border-radius: 4px;
+    padding: 1px 6px;
+    margin-right: 6px;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
 .tool-section pre {
     margin: 0;
     padding: 10px;
@@ -2454,6 +2478,8 @@ M src/routes.ts</code></pre>
                             
                             
                             
+                            
+                            
                             <a href="#io-dev-server-read-1"
                                class="shell-conv-pill"
                                id="pill-dev-server-read-1"
@@ -2590,6 +2616,8 @@ M src/routes.ts</code></pre>
                             
                             
                             
+                            
+                            
                             <a href="#io-dev-server-write-1"
                                class="shell-conv-pill"
                                id="pill-dev-server-write-1"
@@ -2675,6 +2703,8 @@ M src/routes.ts</code></pre>
                             
                             
                         
+                            
+                            
                             
                             
                             

--- a/tests/snapshots/baselines/cli-with-external-tools.html
+++ b/tests/snapshots/baselines/cli-with-external-tools.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Create and edit files via CLI tools - Create and edit files via CLI tools</title>
+    <title>Exercise external (host-app) tool rendering - Exercise external (host-app) tool rendering</title>
     
     <style>
 :root {
@@ -2208,7 +2208,7 @@ input:checked + .toggle-switch::after {
     </style>
     
 </head>
-<body class="hide-thinking hide-diffs hide-tool-inputs">
+<body>
     
 
     <main class="container">
@@ -2216,14 +2216,12 @@ input:checked + .toggle-switch::after {
 
         <div class="session-detail-meta">
             
-            <span>📁 /home/user/myproject</span>
-            
             
             <span>Created: 2026-01-31T12:00:00Z</span>
             
-            <small>ID: <code>cli-file-changes-session</code></small>
+            <small>ID: <code>cli-external-tools-test-session</code></small>
             
-            <small>Source: <code>cli-file-changes</code></small>
+            <small>Source: <code>cli-with-external-tools</code></small>
             
         </div>
 
@@ -2257,7 +2255,7 @@ input:checked + .toggle-switch::after {
                     
                     
                         
-                        <p>Create utils.py and then tweak it.</p>
+                        <p>Rename this session, reply to the review thread, and open the PR.</p>
                     
 
                 
@@ -2303,7 +2301,7 @@ input:checked + .toggle-switch::after {
                             
                             
                             <div class="content-block content-block-text result-block">
-                                <p>Creating the file and editing it.</p>
+                                <p>On it - renaming the session and branch, replying to the comment, then opening the PR.</p>
                             </div>
                             
                             
@@ -2332,9 +2330,43 @@ input:checked + .toggle-switch::after {
                             
                             
                             
-                            
-                            <div class="content-block content-block-toolInvocation tool-invocation-unmatched">
-                                <div class="tool-invocation-message"><p>Created <code>utils.py</code></p></div>
+                            <div class="content-block content-block-toolInvocation tool-invocation-inline">
+                                <details class="tool-invocation-wrapper" open>
+                                    <summary>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        <span class="external-tool-badge">external tool</span>
+                                        <span class="tool-invocation-message"><p>rename_session</p></span>
+                                        
+                                    </summary>
+                                    <div class="tool-invocation-content">
+                                        <div class="tool-section tool-section-meta">
+                                            <span class="tool-label">Tool:</span>
+                                            <code>rename_session</code>
+                                        </div>
+                                        
+                                        
+                                        
+                                        <div class="tool-section tool-section-input">
+                                            <span class="tool-label">Input:</span>
+                                            <pre><code><span class="highlighted-code"><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;title&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Upstream sync plan&quot;</span>
+<span class="p">}</span>
+</span></code></pre>
+                                        </div>
+                                        
+                                        
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
+                                        </div>
+                                        
+                                    </div>
+                                </details>
+                                
+                                <div class="tool-invocation-inline-fallback">
+                                    <p>rename_session</p>
+                                    
+                                </div>
                             </div>
                             
                             
@@ -2365,9 +2397,43 @@ input:checked + .toggle-switch::after {
                             
                             
                             
-                            
-                            <div class="content-block content-block-toolInvocation tool-invocation-unmatched">
-                                <div class="tool-invocation-message"><p>Edited <code>utils.py</code></p></div>
+                            <div class="content-block content-block-toolInvocation tool-invocation-inline">
+                                <details class="tool-invocation-wrapper" open>
+                                    <summary>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        <span class="external-tool-badge">external tool</span>
+                                        <span class="tool-invocation-message"><p>rename_branch</p></span>
+                                        
+                                    </summary>
+                                    <div class="tool-invocation-content">
+                                        <div class="tool-section tool-section-meta">
+                                            <span class="tool-label">Tool:</span>
+                                            <code>rename_branch</code>
+                                        </div>
+                                        
+                                        
+                                        
+                                        <div class="tool-section tool-section-input">
+                                            <span class="tool-label">Input:</span>
+                                            <pre><code><span class="highlighted-code"><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;upstream-sync-plan&quot;</span>
+<span class="p">}</span>
+</span></code></pre>
+                                        </div>
+                                        
+                                        
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
+                                        </div>
+                                        
+                                    </div>
+                                </details>
+                                
+                                <div class="tool-invocation-inline-fallback">
+                                    <p>rename_branch</p>
+                                    
+                                </div>
                             </div>
                             
                             
@@ -2398,9 +2464,46 @@ input:checked + .toggle-switch::after {
                             
                             
                             
-                            
-                            <div class="content-block content-block-toolInvocation tool-invocation-unmatched">
-                                <div class="tool-invocation-message"><p>Edited <code>missing.py</code></p></div>
+                            <div class="content-block content-block-toolInvocation tool-invocation-inline">
+                                <details class="tool-invocation-wrapper" open>
+                                    <summary>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        <span class="external-tool-badge">external tool</span>
+                                        <span class="tool-invocation-message"><p>reply_to_comment</p></span>
+                                        
+                                    </summary>
+                                    <div class="tool-invocation-content">
+                                        <div class="tool-section tool-section-meta">
+                                            <span class="tool-label">Tool:</span>
+                                            <code>reply_to_comment</code>
+                                        </div>
+                                        
+                                        
+                                        
+                                        <div class="tool-section tool-section-input">
+                                            <span class="tool-label">Input:</span>
+                                            <pre><code><span class="highlighted-code"><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;threadId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;thread:cb55bb1d&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;commentId&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;cb55bb1d&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;threadToken&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;9e3d30cf&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;response&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Trimmed the line to just the credit. New line reads:\n\n&gt; Forked from holman/dotfiles.&quot;</span>
+<span class="p">}</span>
+</span></code></pre>
+                                        </div>
+                                        
+                                        
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
+                                        </div>
+                                        
+                                    </div>
+                                </details>
+                                
+                                <div class="tool-invocation-inline-fallback">
+                                    <p>reply_to_comment</p>
+                                    
+                                </div>
                             </div>
                             
                             
@@ -2410,73 +2513,277 @@ input:checked + .toggle-switch::after {
                             
                             
                             <div class="content-block content-block-text result-block">
-                                <p>Done: created utils.py and added a multiply helper.</p>
+                                <p>Annotating the risky line, then opening the PR.</p>
                             </div>
                             
                             
                         
-                    
-
-                
-                
-                
-                    
-                    
-                
-                    
-                    
-                
-                    
-                    
-                
-                
-                
-
-                
-                <p class="tool-summary tool-summary-files"><em>Changed 1 file: /home/user/myproject/utils.py</em></p>
-                <details class="collapsible file-changes" open>
-                    <summary aria-label="Toggle file changes section">
-                        <span class="collapsible-icon" aria-hidden="true">▼</span>
-                        File Changes (1)
-                        <span class="preview-text">utils.py</span>
-                    </summary>
-                    <div class="collapsible-content">
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            <div class="content-block content-block-toolInvocation tool-invocation-unmatched">
+                                <div class="tool-invocation-message"><p>Searching for <code>TODO</code> in <code>app.py</code></p></div>
+                            </div>
+                            
+                            
+                            
+                            
                         
-                        <div class="file-change">
-                            <div class="file-header">
-                                <strong>utils.py</strong>
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            <div class="content-block content-block-toolInvocation tool-invocation-inline">
+                                <details class="tool-invocation-wrapper" open>
+                                    <summary>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        <span class="external-tool-badge">external tool</span>
+                                        <span class="tool-invocation-message"><p>annotate_diff_line</p></span>
+                                        
+                                    </summary>
+                                    <div class="tool-invocation-content">
+                                        <div class="tool-section tool-section-meta">
+                                            <span class="tool-label">Tool:</span>
+                                            <code>annotate_diff_line</code>
+                                        </div>
+                                        
+                                        
+                                        
+                                        <div class="tool-section tool-section-input">
+                                            <span class="tool-label">Input:</span>
+                                            <pre><code><span class="highlighted-code"><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;file&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;src/app.py&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;line&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">42</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;title&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Unhandled refresh&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;explanation&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;This branch never refreshes the token.&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;severity&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;warning&quot;</span>
+<span class="p">}</span>
+</span></code></pre>
+                                        </div>
+                                        
+                                        
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
+                                        </div>
+                                        
+                                    </div>
+                                </details>
                                 
-                                <span class="language-badge">python</span>
-                                
-                                
-                                
-                                <span class="file-stats">
-                                    <span class="file-stat-add">+10</span>
+                                <div class="tool-invocation-inline-fallback">
+                                    <p>annotate_diff_line</p>
                                     
-                                </span>
-                                
+                                </div>
                             </div>
                             
                             
-                            <pre class="diff"><code>--- a/utils.py
-+++ b/utils.py
-@@ -0,0 +1,10 @@
-+def add(a, b):
-+    return a + b
-+
-+
-+def sub(a, b):
-+    return a - b
-+
-+
-+def mul(a, b):
-+    return a * b
-</code></pre>
                             
-                        </div>
+                            
                         
-                    </div>
-                </details>
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            <div class="content-block content-block-toolInvocation tool-invocation-inline">
+                                <details class="tool-invocation-wrapper" open>
+                                    <summary>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        <span class="external-tool-badge">external tool</span>
+                                        <span class="tool-invocation-message"><p>list_sessions_and_chats</p></span>
+                                        
+                                    </summary>
+                                    <div class="tool-invocation-content">
+                                        <div class="tool-section tool-section-meta">
+                                            <span class="tool-label">Tool:</span>
+                                            <code>list_sessions_and_chats</code>
+                                        </div>
+                                        
+                                        
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
+                                        </div>
+                                        
+                                    </div>
+                                </details>
+                                
+                                <div class="tool-invocation-inline-fallback">
+                                    <p>list_sessions_and_chats</p>
+                                    
+                                </div>
+                            </div>
+                            
+                            
+                            
+                            
+                        
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            <div class="content-block content-block-toolInvocation tool-invocation-inline">
+                                <details class="tool-invocation-wrapper" open>
+                                    <summary>
+                                        <span class="collapsible-icon" aria-hidden="true">▼</span>
+                                        <span class="external-tool-badge">external tool</span>
+                                        <span class="tool-invocation-message"><p>create_pull_request</p></span>
+                                        
+                                    </summary>
+                                    <div class="tool-invocation-content">
+                                        <div class="tool-section tool-section-meta">
+                                            <span class="tool-label">Tool:</span>
+                                            <code>create_pull_request</code>
+                                        </div>
+                                        
+                                        
+                                        
+                                        <div class="tool-section tool-section-input">
+                                            <span class="tool-label">Input:</span>
+                                            <pre><code><span class="highlighted-code"><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;title&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Enrich external-tool rendering&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;body&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Render parameters for external tools and note that no response is recorded.&quot;</span>
+<span class="p">}</span>
+</span></code></pre>
+                                        </div>
+                                        
+                                        
+                                        <div class="tool-section tool-section-output tool-section-no-response">
+                                            <span class="tool-label">Response:</span>
+                                            <span class="tool-no-response">Not recorded — this tool is run by the host application, which does not return a result into the session.</span>
+                                        </div>
+                                        
+                                    </div>
+                                </details>
+                                
+                                <div class="tool-invocation-inline-fallback">
+                                    <p>create_pull_request</p>
+                                    
+                                </div>
+                            </div>
+                            
+                            
+                            
+                            
+                        
+                            
+                            
+                            <div class="content-block content-block-text result-block">
+                                <p>Done - session renamed, comment replied, line annotated, and PR opened.</p>
+                            </div>
+                            
+                            
+                        
+                    
+
+                
+                
+                
+                    
+                    
+                
+                    
+                    
+                
+                    
+                    
+                
+                    
+                    
+                
+                    
+                    
+                
+                    
+                    
+                
+                    
+                    
+                
+                
+                
+
                 
 
                 

--- a/tests/snapshots/baselines/cli-with-external-tools.md
+++ b/tests/snapshots/baselines/cli-with-external-tools.md
@@ -1,0 +1,47 @@
+# Chat Session
+
+**Title:** Exercise external (host-app) tool rendering
+
+## Metadata
+
+- **Session ID:** `cli-external-tools-test-session`
+- **Created:** 2026-01-31T12:00:00Z
+- **Updated:** 2024-02-01 00:00:16
+- **Edition:** `cli`
+- **Messages:** 2
+
+---
+
+## Message 1: **USER**
+
+*2024-02-01 00:00:01*
+
+Rename this session, reply to the review thread, and open the PR.
+
+---
+
+## Message 2: **ASSISTANT**
+
+*2024-02-01 00:00:02*
+
+On it - renaming the session and branch, replying to the comment, then opening the PR.
+
+*🔧 rename_session*
+
+*🔧 rename_branch*
+
+*🔧 reply_to_comment*
+
+Annotating the risky line, then opening the PR.
+
+*🔧 Searching for `TODO` in `app.py`*
+
+*🔧 annotate_diff_line*
+
+*🔧 list_sessions_and_chats*
+
+*🔧 create_pull_request*
+
+Done - session renamed, comment replied, line annotated, and PR opened.
+
+---

--- a/tests/snapshots/fixtures/cli-with-external-tools/events.jsonl
+++ b/tests/snapshots/fixtures/cli-with-external-tools/events.jsonl
@@ -1,0 +1,19 @@
+{"type": "session.start", "timestamp": 1706745600, "data": {"sessionId": "cli-external-tools-test-session", "startTime": "2026-01-31T12:00:00Z"}}
+{"type": "user.message", "timestamp": 1706745601, "data": {"content": "Rename this session, reply to the review thread, and open the PR."}}
+{"type": "assistant.message", "timestamp": 1706745602, "data": {"content": "On it - renaming the session and branch, replying to the comment, then opening the PR."}}
+{"type": "external_tool.requested", "timestamp": 1706745603, "data": {"requestId": "ext-1", "sessionId": "cli-external-tools-test-session", "toolCallId": "tc-ext-1", "toolName": "rename_session", "arguments": {"title": "Upstream sync plan"}}}
+{"type": "external_tool.completed", "timestamp": 1706745604, "data": {"requestId": "ext-1"}}
+{"type": "external_tool.requested", "timestamp": 1706745605, "data": {"requestId": "ext-2", "sessionId": "cli-external-tools-test-session", "toolCallId": "tc-ext-2", "toolName": "rename_branch", "arguments": {"name": "upstream-sync-plan"}}}
+{"type": "external_tool.completed", "timestamp": 1706745606, "data": {"requestId": "ext-2"}}
+{"type": "external_tool.requested", "timestamp": 1706745607, "data": {"requestId": "ext-3", "sessionId": "cli-external-tools-test-session", "toolCallId": "tc-ext-3", "toolName": "reply_to_comment", "arguments": {"threadId": "thread:cb55bb1d", "commentId": "cb55bb1d", "threadToken": "9e3d30cf", "response": "Trimmed the line to just the credit. New line reads:\n\n> Forked from holman/dotfiles."}}}
+{"type": "external_tool.completed", "timestamp": 1706745608, "data": {"requestId": "ext-3"}}
+{"type": "assistant.message", "timestamp": 1706745609, "data": {"content": "Annotating the risky line, then opening the PR.", "toolRequests": [{"toolCallId": "tc-grep-1", "name": "grep", "arguments": {"pattern": "TODO", "path": "src/app.py"}}]}}
+{"type": "tool.execution_start", "timestamp": 1706745610, "data": {"toolCallId": "tc-grep-1", "toolName": "grep", "arguments": {"pattern": "TODO", "path": "src/app.py"}}}
+{"type": "tool.execution_complete", "timestamp": 1706745611, "data": {"toolCallId": "tc-grep-1", "toolName": "grep", "success": true, "result": {"content": "src/app.py:42: # TODO: handle refresh"}}}
+{"type": "external_tool.requested", "timestamp": 1706745612, "data": {"requestId": "ext-4", "sessionId": "cli-external-tools-test-session", "toolCallId": "tc-ext-4", "toolName": "annotate_diff_line", "arguments": {"file": "src/app.py", "line": 42, "title": "Unhandled refresh", "explanation": "This branch never refreshes the token.", "severity": "warning"}}}
+{"type": "external_tool.completed", "timestamp": 1706745613, "data": {"requestId": "ext-4"}}
+{"type": "external_tool.requested", "timestamp": 1706745613, "data": {"requestId": "ext-noarg", "sessionId": "cli-external-tools-test-session", "toolCallId": "tc-ext-noarg", "toolName": "list_sessions_and_chats"}}
+{"type": "external_tool.completed", "timestamp": 1706745613, "data": {"requestId": "ext-noarg"}}
+{"type": "external_tool.requested", "timestamp": 1706745614, "data": {"requestId": "ext-5", "sessionId": "cli-external-tools-test-session", "toolCallId": "tc-ext-5", "toolName": "create_pull_request", "arguments": {"title": "Enrich external-tool rendering", "body": "Render parameters for external tools and note that no response is recorded."}}}
+{"type": "external_tool.completed", "timestamp": 1706745615, "data": {"requestId": "ext-5"}}
+{"type": "assistant.message", "timestamp": 1706745616, "data": {"content": "Done - session renamed, comment replied, line annotated, and PR opened."}}

--- a/tests/snapshots/fixtures/cli-with-external-tools/workspace.yaml
+++ b/tests/snapshots/fixtures/cli-with-external-tools/workspace.yaml
@@ -1,0 +1,3 @@
+id: cli-external-tools-test-session
+cwd: /home/user/myproject
+summary: Exercise external (host-app) tool rendering

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2120,7 +2120,7 @@ class TestCLINewEventHandlers:
         )
 
         assert session is not None
-        assert self._find_status_blocks(session, "external-tool")[0].content == "External tool requested: ext"
+        assert self._find_status_blocks(session, "external-tool") == []
         assert self._find_status_blocks(session, "command")[0].content == "Command queued: npm test"
         assert self._find_status_blocks(session, "truncation")[0].content == "Context truncated: context_window"
         assert self._find_status_blocks(session, "workspace-file")[0].content == "Workspace file changed: updated src/app.py"
@@ -2138,6 +2138,72 @@ class TestCLINewEventHandlers:
 
         assert session is not None
         assert self._find_status_blocks(session, "hook-error")[0].content == "Hook failed: postToolUse - blocked"
+
+    def _find_tool_invocations(self, session, name=None):
+        """Return all tool invocations across messages, optionally filtered by name."""
+        tools = []
+        for msg in session.messages:
+            for tool in msg.tool_invocations:
+                if name is None or tool.name == name:
+                    tools.append(tool)
+        return tools
+
+    def test_external_tool_renders_with_parameters(self, tmp_path):
+        """external_tool.requested should render as a tool block exposing its parameters."""
+        session = self._parse(
+            tmp_path,
+            {"type": "user.message", "data": {"content": "Rename it"}},
+            {"type": "assistant.message", "data": {"content": "Renaming."}},
+            {
+                "type": "external_tool.requested",
+                "data": {
+                    "requestId": "r1",
+                    "toolCallId": "tc1",
+                    "toolName": "rename_session",
+                    "arguments": {"title": "Upstream sync plan"},
+                },
+            },
+            {"type": "external_tool.completed", "data": {"requestId": "r1"}},
+        )
+
+        assert session is not None
+        # No longer a thin status breadcrumb.
+        assert self._find_status_blocks(session, "external-tool") == []
+        # Rendered as a proper tool invocation carrying the parameters.
+        tools = self._find_tool_invocations(session, "rename_session")
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.source_type == "external"
+        # Parameters are preserved in the serialized input.
+        assert tool.input is not None
+        assert "Upstream sync plan" in tool.input
+        # The host does not record a response, so result stays unset.
+        assert tool.result is None
+        # Label falls back to the tool name (same default as builtin tools without a
+        # specific format) — the parameters live in the input, not the header.
+        assert tool.invocation_message == "rename_session"
+        # A matching inline content block exists for template pairing.
+        tool_blocks = [cb for msg in session.messages for cb in msg.content_blocks if cb.kind == "toolInvocation"]
+        assert any(cb.content == "rename_session" for cb in tool_blocks)
+
+    def test_external_tool_without_arguments(self, tmp_path):
+        """An external tool with no arguments still renders as a tool block, not a status line."""
+        session = self._parse(
+            tmp_path,
+            {"type": "assistant.message", "data": {"content": "Working."}},
+            {
+                "type": "external_tool.requested",
+                "data": {"requestId": "r2", "toolCallId": "tc2", "toolName": "list_sessions_and_chats"},
+            },
+            {"type": "external_tool.completed", "data": {"requestId": "r2"}},
+        )
+
+        assert session is not None
+        assert self._find_status_blocks(session, "external-tool") == []
+        tools = self._find_tool_invocations(session, "list_sessions_and_chats")
+        assert len(tools) == 1
+        assert tools[0].source_type == "external"
+        assert tools[0].result is None
 
 
 class TestCLISubagentBrackets:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -93,6 +93,65 @@ class TestCLIAgentSessionSnapshot:
         file_regression.check(html, fullpath=BASELINES_DIR / "cli-with-agents.html", encoding="utf-8")
 
 
+# --- CLI Session with External (host-app) Tools Snapshots ---
+
+_cli_external_tools_events = FIXTURES_DIR / "cli-with-external-tools" / "events.jsonl"
+_cli_external_tools_fixture_exists = _cli_external_tools_events.exists() if FIXTURES_DIR.exists() else False
+
+
+@pytest.mark.skipif(not _cli_external_tools_fixture_exists, reason="CLI external tools fixture not populated")
+class TestCLIExternalToolsSnapshot:
+    """Snapshot tests for CLI session with external (host-app) tool rendering."""
+
+    session: ChatSession
+
+    @pytest.fixture(autouse=True)
+    def parse_session(self):
+        parsed = _parse_cli_jsonl_file(_cli_external_tools_events)
+        assert parsed is not None, f"Failed to parse CLI external tools fixture: {_cli_external_tools_events}"
+        self.session = parsed
+        self.session.source_file = "cli-with-external-tools"
+
+    def test_markdown_export(self, file_regression):
+        md = session_to_markdown(
+            self.session,
+            content_set={"diffs", "tool-inputs", "thinking", "agent-details", "tools", "commands", "file-changes"},
+        )
+        file_regression.check(md, fullpath=BASELINES_DIR / "cli-with-external-tools.md", encoding="utf-8")
+
+    def test_html_export(self, file_regression):
+        html = session_to_html(
+            self.session,
+            content_set={"diffs", "tool-inputs", "thinking", "agent-details", "tools", "commands", "file-changes"},
+        )
+        file_regression.check(html, fullpath=BASELINES_DIR / "cli-with-external-tools.html", encoding="utf-8")
+
+    def test_external_tools_parsed(self):
+        """External tools render as ToolInvocations carrying parameters but no result."""
+        external = [t for msg in self.session.messages for t in msg.tool_invocations if t.source_type == "external"]
+        names = sorted(t.name for t in external)
+        assert names == [
+            "annotate_diff_line",
+            "create_pull_request",
+            "list_sessions_and_chats",
+            "rename_branch",
+            "rename_session",
+            "reply_to_comment",
+        ]
+        # Every external tool records no response; all but the no-arg one expose parameters.
+        for tool in external:
+            assert tool.result is None, f"external tool {tool.name} should not record a response"
+        assert all(t.input for t in external if t.name != "list_sessions_and_chats")
+        # The no-argument external tool still parses as an external ToolInvocation.
+        noarg = [t for t in external if t.name == "list_sessions_and_chats"]
+        assert len(noarg) == 1
+
+    def test_external_tools_not_status_blocks(self):
+        """External tools must not leak through as bare status breadcrumbs."""
+        status_descs = [cb.description for msg in self.session.messages for cb in msg.content_blocks if cb.kind == "status"]
+        assert "external-tool" not in status_descs
+
+
 # --- CLI Session with Async Shells Snapshots ---
 
 _cli_async_shells_events = FIXTURES_DIR / "cli-with-async-shells" / "events.jsonl"

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "copilot-session-tools"
-version = "0.17.1"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Why

When viewing an archived session, external tools, the host-app/IDE actions like `rename_session`, `reply_to_comment`, `create_pull_request`, and `annotate_diff_line`, used to collapse into a single status line ("External tool requested: X"). That threw away the call's parameters, so reviewers reading a transcript could not see what the tool actually did, and the missing response was unexplained.

## What changed

External tool events (`external_tool.requested` / `external_tool.completed`) now parse into a real `ToolInvocation` (`source_type="external"`) and render as a collapsible block that exposes the parameters, the same way MCP tool calls already do. This flows through the web viewer and the static HTML export (they share the `session.html` template); Markdown export shows the tool label inline, consistent with how it treats every other tool.

A couple of deliberate design points:

- **The response is genuinely not in the data.** Across every real occurrence I sampled, `external_tool.completed` carries only a `requestId`, no result, success, or error. The host application runs these tools fire-and-forget and never returns a payload into the session. So instead of silently dropping it, the block shows an explicit "Response: Not recorded" note. External tools are always collapsible (even when they take no arguments) so this note is always visible.
- **An `external tool` badge** in the collapsible header distinguishes host-app tools from CLI tools at a glance, mirroring how MCP tools advertise their source. It is presentation-only (template + CSS); the stored data is unchanged.
- **The label is just the tool name.** External tools fall back to the same default as builtin tools without a bespoke format (`description or tool_name`), rather than a hardcoded per-tool table or name humanizing, so unknown or future external tools are handled uniformly with no maintenance.

## Compatibility

No schema change. `source_type` is an existing column and `external` is just a new value in it; no new tables, columns, or content-block kinds, so `CST_SCHEMA_VERSION` is untouched. Mixing this build and the released build against the same database is safe in both directions (an older renderer that does not know `external` degrades gracefully to showing the tool label). The version bump triggers the normal Phase 3 re-enrichment so existing CLI sessions pick up the new rendering on upgrade.

## Tests / verification

- New scanner unit tests plus a `cli-with-external-tools` snapshot fixture with HTML/Markdown baselines.
- Full suite green (863 passed); ruff, format, and ty clean.
- Visually verified against a real archived session and a synthetic one:

![External tool blocks showing parameters and the not-recorded response note](https://github.com/user-attachments/assets/66f3c4de-0a74-426d-8dc7-f3d59ef17bcf)